### PR TITLE
First proposal for the MixedMapper and MixedOp

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -62,6 +62,7 @@ bopes
 boson
 bosons
 bosonic
+bosoniclinearmapper
 bosonicop
 bravais
 bravyi

--- a/qiskit_nature/second_q/mappers/__init__.py
+++ b/qiskit_nature/second_q/mappers/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
+# (C) Copyright IBM 2022, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/mappers/__init__.py
+++ b/qiskit_nature/second_q/mappers/__init__.py
@@ -128,6 +128,7 @@ __all__ = [
     "BosonicLinearMapper",
     "BosonicLogarithmicMapper",
     "LogarithmicMapper",
+    "MixedMapper",
     "QubitMapper",
     "InterleavedQubitMapper",
     "TaperedQubitMapper",

--- a/qiskit_nature/second_q/mappers/__init__.py
+++ b/qiskit_nature/second_q/mappers/__init__.py
@@ -133,5 +133,4 @@ __all__ = [
     "InterleavedQubitMapper",
     "TaperedQubitMapper",
     "ModeBasedMapper",
-    "MixedMapper",
 ]

--- a/qiskit_nature/second_q/mappers/__init__.py
+++ b/qiskit_nature/second_q/mappers/__init__.py
@@ -92,6 +92,15 @@ after the mapping to qubit operators, you can use the following wrapper for symm
 
    TaperedQubitMapper
 
+MixedOp Mappers
++++++++++++++++
+
+.. autosummary::
+   :toctree: ../stubs/
+   :nosignatures:
+
+   MixedMapper
+
 """
 
 from .bksf import BravyiKitaevSuperFastMapper
@@ -107,6 +116,7 @@ from .qubit_mapper import QubitMapper
 from .mode_based_mapper import ModeBasedMapper
 from .interleaved_qubit_mapper import InterleavedQubitMapper
 from .tapered_qubit_mapper import TaperedQubitMapper
+from .mixed_mapper import MixedMapper
 
 __all__ = [
     "BravyiKitaevMapper",
@@ -122,4 +132,5 @@ __all__ = [
     "InterleavedQubitMapper",
     "TaperedQubitMapper",
     "ModeBasedMapper",
+    "MixedMapper",
 ]

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2024.
+# (C) Copyright IBM 2023, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -13,6 +13,8 @@
 """The Mixed Mapper class."""
 
 from __future__ import annotations
+
+from abc import ABC
 from functools import reduce
 
 import logging

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -77,6 +77,17 @@ class MixedMapper(ABC):
         self.hilbert_space_register_lengths: dict[str, int] = hilbert_space_register_lengths
         self.hilbert_space_register_types: dict[str, SparseLabelOp] = hilbert_space_register_types
 
+    def _extend_mapping(self, op: SparsePauliOp, register, tot_register_length):
+        left_length = register[0]
+        right_length = register[1]
+        if left_length!=0:
+            left_pad = SparsePauliOp("Z"*left_length) 
+            op = left_pad.tensor(op)
+        if right_length!=0:
+            right_pad = SparsePauliOp("I"*right_length)
+            op = op.tensor(right_pad)
+        return op
+
     def _map_tuple_product(
         self, active_indices: tuple[str], active_operators: tuple[SparseLabelOp]
     ) -> SparsePauliOp:

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -20,7 +20,7 @@ from functools import reduce
 
 from qiskit.quantum_info import SparsePauliOp
 from qiskit_algorithms.list_or_dict import ListOrDict as ListOrDictType
-from qiskit_nature.second_q.operators import MixedOp, SparseLabelOp
+from qiskit_nature.second_q.operators import MixedOp, SparseLabelOp, FermionicOp
 
 from .qubit_mapper import QubitMapper, _ListOrDict
 
@@ -101,6 +101,14 @@ class MixedMapper(ABC):
         self.hilbert_space_register_types: dict[str, type[SparseLabelOp]] = (
             hilbert_space_register_types
         )
+
+        # Only one fermionic register allowed to ensure fermionic statistics.
+        count_fermionic_registers = [
+            issubclass(register_type, FermionicOp)
+            for register_type in self.hilbert_space_register_types.values()
+        ]
+        if sum(count_fermionic_registers) > 1:
+            raise ValueError("Register types can only contain a single fermionic register")
 
     def _map_tuple_product(
         self, active_indices: tuple[str], active_operators: tuple[SparseLabelOp]

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -63,7 +63,7 @@ class MixedMapper(ABC):
         self,
         mappers: dict[str, QubitMapper],
         hilbert_space_register_lengths: dict[str, int],
-        hilbert_space_register_types: dict[str, SparseLabelOp],
+        hilbert_space_register_types: dict[str, type[SparseLabelOp]],
     ):
         """
         Args:
@@ -73,7 +73,9 @@ class MixedMapper(ABC):
         super().__init__()
         self.mappers: dict[str, QubitMapper] = mappers
         self.hilbert_space_register_lengths: dict[str, int] = hilbert_space_register_lengths
-        self.hilbert_space_register_types: dict[str, SparseLabelOp] = hilbert_space_register_types
+        self.hilbert_space_register_types: dict[str, type[SparseLabelOp]] = (
+            hilbert_space_register_types
+        )
 
     def _map_tuple_product(
         self, active_indices: tuple[str], active_operators: tuple[SparseLabelOp]

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -30,7 +30,8 @@ LOGGER = logging.getLogger(__name__)
 class MixedMapper(ABC):
     """Mapper of a Mixed Operator to a Qubit Operator.
 
-    This class is to be used to map systems with particles of different nature, such as bosons and fermions.
+    This class is to be used to map systems with particles of different nature,
+    such as bosons and fermions.
 
     Please note that the creation and usage of this class requires the precise definition of the
     composite Hilbert size corresponding to the problem.
@@ -78,8 +79,8 @@ class MixedMapper(ABC):
 
     Attributes:
         mappers: Dictionary of mappers corresponding to "local" Hilbert spaces of the global problem.
-        hilbert_space_register_lengths: Ordered dictionary of local registers and their respective sizes.
-        hilbert_space_register_types: Ordered dictionary of local registers and their respective types.
+        hilbert_space_register_lengths: Ordered dictionary of local registers sizes.
+        hilbert_space_register_types: Ordered dictionary of local registers types.
     """
 
     def __init__(
@@ -91,8 +92,8 @@ class MixedMapper(ABC):
         """
         Args:
             mappers: Dictionary of mappers corresponding to the "local" Hilbert spaces.
-            hilbert_space_register_lengths: Ordered dictionary of local registers with their sizes.
-            hilbert_space_register_types: Ordered dictionary of local registers and their respective types.
+            hilbert_space_register_lengths: Ordered dictionary of local registers sizes.
+            hilbert_space_register_types: Ordered dictionary of local register types.
         """
         super().__init__()
         self.mappers: dict[str, QubitMapper] = mappers

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 from abc import ABC
 from functools import reduce
 

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -18,18 +18,8 @@ import logging
 from abc import ABC
 from functools import reduce
 
-import logging
-from abc import ABC
-from functools import reduce
-
-import logging
-from abc import ABC
-from functools import reduce
-
 from qiskit.quantum_info import SparsePauliOp
-
 from qiskit_algorithms.list_or_dict import ListOrDict as ListOrDictType
-
 from qiskit_nature.second_q.operators import MixedOp, SparseLabelOp
 
 from .qubit_mapper import QubitMapper, _ListOrDict

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -85,7 +85,7 @@ class MixedMapper(ABC):
         right_length = register[0]
         left_length = register[1]
         if right_length!=0:
-            right_pad = SparsePauliOp("Z"*right_length)
+            right_pad = SparsePauliOp("I"*right_length)
             op = op.tensor(right_pad)
         if left_length!=0:
             left_pad = SparsePauliOp("I"*left_length) 

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -13,6 +13,7 @@
 """The Mixed Mapper class."""
 
 from __future__ import annotations
+from functools import reduce
 
 import logging
 from abc import ABC
@@ -80,17 +81,6 @@ class MixedMapper(ABC):
         self.mappers: dict[str, QubitMapper] = mappers
         self.hilbert_space_register_lengths: dict[str, int] = hilbert_space_register_lengths
         self.hilbert_space_register_types: dict[str, SparseLabelOp] = hilbert_space_register_types
-
-    def _extend_mapping(self, op: SparsePauliOp, register, tot_register_length):
-        right_length = register[0]
-        left_length = register[1]
-        if right_length!=0:
-            right_pad = SparsePauliOp("I"*right_length)
-            op = op.tensor(right_pad)
-        if left_length!=0:
-            left_pad = SparsePauliOp("I"*left_length) 
-            op = left_pad.tensor(op)
-        return op
 
     def _map_tuple_product(
         self, active_indices: tuple[str], active_operators: tuple[SparseLabelOp]

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -81,6 +81,17 @@ class MixedMapper(ABC):
         self.hilbert_space_register_lengths: dict[str, int] = hilbert_space_register_lengths
         self.hilbert_space_register_types: dict[str, SparseLabelOp] = hilbert_space_register_types
 
+    def _extend_mapping(self, op: SparsePauliOp, register, tot_register_length):
+        left_length = register[0]
+        right_length = register[1]
+        if left_length!=0:
+            left_pad = SparsePauliOp("Z"*left_length) 
+            op = left_pad.tensor(op)
+        if right_length!=0:
+            right_pad = SparsePauliOp("I"*right_length)
+            op = op.tensor(right_pad)
+        return op
+
     def _map_tuple_product(
         self, active_indices: tuple[str], active_operators: tuple[SparseLabelOp]
     ) -> SparsePauliOp:

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -81,7 +81,7 @@ class MixedMapper(ABC):
         right_length = register[0]
         left_length = register[1]
         if right_length!=0:
-            right_pad = SparsePauliOp("Z"*right_length)
+            right_pad = SparsePauliOp("I"*right_length)
             op = op.tensor(right_pad)
         if left_length!=0:
             left_pad = SparsePauliOp("I"*left_length) 

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -1,0 +1,183 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2023, 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""The Mixed Mapper class."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC
+from functools import reduce
+
+from qiskit.quantum_info import SparsePauliOp
+
+from qiskit_algorithms.list_or_dict import ListOrDict as ListOrDictType
+
+from qiskit_nature.second_q.operators import MixedOp, SparseLabelOp
+
+from .qubit_mapper import QubitMapper, _ListOrDict
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MixedMapper(ABC):
+    """Mapper of a Mixed Operator to a Qubit Operator.
+
+    This class is intended to be used for handling the mapping of composed fermionic and (or) bosonic
+    systems, defined as :class:`~qiskit_nature.second_q.operators.MixedOp`, into qubit operators.
+
+    Please note that the creation and usage of this class requires the precise definition of the
+    composite Hilbert size corresponding to the problem.
+    The ordering of the qubit registers associated to the bosonic and fermionic degrees of freedom
+    (for example) must be provided by the user through the definition of the hilbert space
+    registers dictionary. This ordering corresponds to a specific way to take the tensor product
+    of the fermionic and bosonic operators.
+
+    .. note::
+
+      This class is limited to one instance of a Fermionic Hilbert space, to ensure the anticommutation
+      relations of the fermions.
+
+    .. note::
+
+      This class enforces the register lengths to the mappers. Note that for the bosonic mappers, the
+      register lengths is not directly equal to the qubit register length but to the number of modes.
+      See the documentation of the class :class:``~.BosonicLinearMapper``.
+
+    The following attributes can be read and updated once the ``MixedMapper`` object has been
+    constructed.
+
+    Attributes:
+        mappers: Dictionary of mappers corresponding to "local" Hilbert spaces of the global problem.
+        hilbert_space_register_lengths: Ordered dictionary of local registers and their respective sizes.
+    """
+
+    def __init__(
+        self,
+        mappers: dict[str, QubitMapper],
+        hilbert_space_register_lengths: dict[str, int],
+        hilbert_space_register_types: dict[str, SparseLabelOp],
+    ):
+        """
+        Args:
+            mappers: Dictionary of mappers corresponding to the "local" Hilbert spaces.
+            hilbert_space_register_lengths: Ordered dictionary of local registers with their sizes.
+        """
+        super().__init__()
+        self.mappers: dict[str, QubitMapper] = mappers
+        self.hilbert_space_register_lengths: dict[str, int] = hilbert_space_register_lengths
+        self.hilbert_space_register_types: dict[str, SparseLabelOp] = hilbert_space_register_types
+
+    def _map_tuple_product(
+        self, active_indices: tuple[str], active_operators: tuple[SparseLabelOp]
+    ) -> SparsePauliOp:
+        """Maps a product of operators defined on the local Hilbert spaces defined by the active
+        indices. Note that the order of the active indices is not relevant. The only relevant ordering
+        is that given by :attr:`~MixedMapper.hilbert_space_register_lengths` at initialization.
+
+        When the operator is not present in the tuple, we use a padding operator with identities.
+
+        Args:
+            active_indices: Reference names of the Hilbert spaces on which the operator acts.
+            active_operators: List of operators to compose..
+        """
+
+        product_op_dict = {
+            index: self.mappers[index].map(
+                self.hilbert_space_register_types[index].one(), register_length=value
+            )
+            for index, value in self.hilbert_space_register_lengths.items()
+        }
+
+        for active_index, active_op in zip(active_indices, active_operators):
+            register_length = self.hilbert_space_register_lengths[active_index]
+            product_op_dict[active_index] = self.mappers[active_index].map(
+                active_op, register_length=register_length
+            )
+
+        product_op = reduce(SparsePauliOp.tensor, list(product_op_dict.values()))
+
+        return product_op
+
+    def _distribute_map(
+        self, operator_dict: dict[tuple[str], list[tuple[float, SparseLabelOp]]]
+    ) -> SparsePauliOp:
+        """Distributes the mapping of operators to each of the terms defined across specific
+        Hilbert spaces.
+
+        Args:
+            operator_dict: Dictionary of (key, operator list) pairs where the key specify which
+                local "Hilbert space" the operators act on. Note that the first element of the
+                operator list is the coefficient of this operator product across these Hilbert spaces.
+        """
+
+        mapped_op: SparsePauliOp = 0
+        for active_indices, operator_list in operator_dict.items():
+            for coef_and_operators in operator_list:
+                coef: float = coef_and_operators[0]
+                active_operators: tuple[SparseLabelOp] = coef_and_operators[1:]
+                mapped_op += coef * self._map_tuple_product(active_indices, active_operators)
+
+        return mapped_op.simplify()
+
+    def _map_single(
+        self,
+        mixed_op: MixedOp,
+        *,
+        register_length: int | None = None,
+    ) -> SparsePauliOp:
+        """Map the :class:`~qiskit_nature.second_q.operators.MixedOp` into a qubit operator.
+
+        The ``MixedOp`` is a representation of sums of products of operators corresponding to different
+        Hilbert spaces. The mapping procedure first runs through all of the terms to be summed,
+        and then maps the operator product by tensoring the individually mapped operators.
+
+        Args:
+            mixed_op: Operator to map.
+            register_length: UNUSED.
+        """
+
+        if register_length is not None:
+            LOGGER.info("Argument register length = %s was ignored.", register_length)
+        mapped_op: SparsePauliOp = self._distribute_map(mixed_op.data)
+
+        return mapped_op
+
+    def map(
+        self,
+        mixed_ops: MixedOp | ListOrDictType[MixedOp],
+        *,
+        register_length: int | None = None,
+    ) -> SparsePauliOp | ListOrDictType[SparsePauliOp]:
+        """Maps a second quantized operator or a list, dict of second quantized operators based on
+        the current mapper.
+
+        Args:
+            mixed_ops: A second quantized operator, or list thereof.
+            register_length: when provided, this will be used to overwrite the ``register_length``
+                attribute of the ``SparseLabelOp`` being mapped. This is possible because the
+                ``register_length`` is considered a lower bound in a ``SparseLabelOp``.
+
+        Returns:
+            A qubit operator in the form of a ``SparsePauliOp``, or list (resp. dict) thereof if a
+            list (resp. dict) of second quantized operators was supplied.
+        """
+        wrapped_second_q_ops, wrapped_type = _ListOrDict.wrap(mixed_ops)
+
+        qubit_ops: _ListOrDict = _ListOrDict()
+        for name, second_q_op in iter(wrapped_second_q_ops):
+            qubit_ops[name] = self._map_single(second_q_op, register_length=register_length)
+
+        returned_ops = qubit_ops.unwrap(wrapped_type)
+        # Note the output of the mapping will never be None for standard mappers other than the
+        # TaperedQubitMapper.
+        return returned_ops

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -82,14 +82,14 @@ class MixedMapper(ABC):
         self.hilbert_space_register_types: dict[str, SparseLabelOp] = hilbert_space_register_types
 
     def _extend_mapping(self, op: SparsePauliOp, register, tot_register_length):
-        left_length = register[0]
-        right_length = register[1]
-        if left_length!=0:
-            left_pad = SparsePauliOp("Z"*left_length) 
-            op = left_pad.tensor(op)
+        right_length = register[0]
+        left_length = register[1]
         if right_length!=0:
-            right_pad = SparsePauliOp("I"*right_length)
+            right_pad = SparsePauliOp("Z"*right_length)
             op = op.tensor(right_pad)
+        if left_length!=0:
+            left_pad = SparsePauliOp("I"*left_length) 
+            op = left_pad.tensor(op)
         return op
 
     def _map_tuple_product(

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -197,7 +197,7 @@ class MixedMapper(ABC):
         """
 
         if register_length is not None:
-            LOGGER.info("Argument register length = %s was ignored.", register_length)
+            LOGGER.warning("Argument register length = %s was ignored.", register_length)
 
         wrapped_second_q_ops, wrapped_type = _ListOrDict.wrap(mixed_ops)
 

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -154,8 +154,6 @@ class MixedMapper(ABC):
     def _map_single(
         self,
         mixed_op: MixedOp,
-        *,
-        register_length: int | None = None,
     ) -> SparsePauliOp:
         """Maps the :class:`~qiskit_nature.second_q.operators.MixedOp` into a qubit operator.
 
@@ -196,7 +194,7 @@ class MixedMapper(ABC):
 
         qubit_ops: _ListOrDict = _ListOrDict()
         for name, second_q_op in iter(wrapped_second_q_ops):
-            qubit_ops[name] = self._map_single(second_q_op, register_length=register_length)
+            qubit_ops[name] = self._map_single(second_q_op)
 
         returned_ops = qubit_ops.unwrap(wrapped_type)
         # Note the output of the mapping will never be None for standard mappers other than the

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -78,14 +78,14 @@ class MixedMapper(ABC):
         self.hilbert_space_register_types: dict[str, SparseLabelOp] = hilbert_space_register_types
 
     def _extend_mapping(self, op: SparsePauliOp, register, tot_register_length):
-        left_length = register[0]
-        right_length = register[1]
-        if left_length!=0:
-            left_pad = SparsePauliOp("Z"*left_length) 
-            op = left_pad.tensor(op)
+        right_length = register[0]
+        left_length = register[1]
         if right_length!=0:
-            right_pad = SparsePauliOp("I"*right_length)
+            right_pad = SparsePauliOp("Z"*right_length)
             op = op.tensor(right_pad)
+        if left_length!=0:
+            left_pad = SparsePauliOp("I"*left_length) 
+            op = left_pad.tensor(op)
         return op
 
     def _map_tuple_product(

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -51,7 +51,7 @@ class MixedMapper(ABC):
         # This follows the qiskit convention for stacking qubit registers from right to left.
         hilbert_space_register_lengths = {"b1": 1, "f1": 1}
         hilbert_space_register_types = {"b1": BosonicOp, "f1": FermionicOp}
-        # One bosonic mode (potentially a qudit with yet unknow local dimension d)
+        # One bosonic mode (yet unknown local dimension d)
         # One fermionic mode (qubit).
         mix_mapper = MixedMapper(
             mappers=mappers,

--- a/qiskit_nature/second_q/mappers/mixed_mapper.py
+++ b/qiskit_nature/second_q/mappers/mixed_mapper.py
@@ -13,6 +13,7 @@
 """The Mixed Mapper class."""
 
 from __future__ import annotations
+from functools import reduce
 
 import logging
 from abc import ABC
@@ -76,17 +77,6 @@ class MixedMapper(ABC):
         self.mappers: dict[str, QubitMapper] = mappers
         self.hilbert_space_register_lengths: dict[str, int] = hilbert_space_register_lengths
         self.hilbert_space_register_types: dict[str, SparseLabelOp] = hilbert_space_register_types
-
-    def _extend_mapping(self, op: SparsePauliOp, register, tot_register_length):
-        right_length = register[0]
-        left_length = register[1]
-        if right_length!=0:
-            right_pad = SparsePauliOp("I"*right_length)
-            op = op.tensor(right_pad)
-        if left_length!=0:
-            left_pad = SparsePauliOp("I"*left_length) 
-            op = left_pad.tensor(op)
-        return op
 
     def _map_tuple_product(
         self, active_indices: tuple[str], active_operators: tuple[SparseLabelOp]

--- a/qiskit_nature/second_q/operators/__init__.py
+++ b/qiskit_nature/second_q/operators/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2024.
+# (C) Copyright IBM 2022, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/operators/__init__.py
+++ b/qiskit_nature/second_q/operators/__init__.py
@@ -31,6 +31,7 @@ Operators and mappers for different systems such as fermionic, vibrational and s
    VibrationalIntegrals
    PolynomialTensor
    Tensor
+   MixedOp
 
 Modules
 -------
@@ -53,6 +54,7 @@ from .vibrational_integrals import VibrationalIntegrals
 from .polynomial_tensor import PolynomialTensor
 from .sparse_label_op import SparseLabelOp
 from .tensor import Tensor
+from .mixed_op import MixedOp
 
 __all__ = [
     "ElectronicIntegrals",
@@ -65,4 +67,5 @@ __all__ = [
     "PolynomialTensor",
     "SparseLabelOp",
     "Tensor",
+    "MixedOp",
 ]

--- a/qiskit_nature/second_q/operators/mixed_op.py
+++ b/qiskit_nature/second_q/operators/mixed_op.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2024.
+# (C) Copyright IBM 2023, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/operators/mixed_op.py
+++ b/qiskit_nature/second_q/operators/mixed_op.py
@@ -1,0 +1,201 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2023, 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""The Mixed Operator class."""
+
+from __future__ import annotations
+
+import itertools
+from copy import deepcopy
+from typing import Callable
+
+from qiskit.quantum_info.operators.mixins import LinearMixin
+
+from .sparse_label_op import SparseLabelOp
+
+
+class MixedOp(LinearMixin):
+    """Mixed operator.
+
+    A ``MixedOp`` represents a weighted sum of products of fermionic/bosonic operators potentially
+    acting on different "local" Hilbert spaces. The terms to be summed are encoded in a dictionary,
+    where each operator product is identified by its key, a tuple of string specifying the names of the
+    local Hilbert spaces on which it acts, and by its value, a list of tuple (corresponding to a sum of
+    operators acting on the same composite Hilbert space) where each tuple encodes the coupling
+    coefficient and the operators themselves (that might also have coefficients associated with them).
+
+
+    **Initialization**
+
+    A ``MixedOp`` is initialized with a dictionary, mapping terms to their respective
+    coefficients:
+
+    .. code-block:: python
+
+        from qiskit_nature.second_q.operators import FermionicOp, SpinOp, MixedOp
+
+        fop1 = FermionicOp({"+_0 -_0": 1}) # Acting on Hilbert space "h1"
+        sop1 = SpinOp({"X_0 Y_0": 1}, num_spins=1) # Acting on Hilbert space "s1"
+
+        mop1 = MixedOp({("h1",): [(5.0, fop1)]}) # 5.0 * fop1
+        mop2 = MixedOp(
+            {
+                ("h1", "s1"): [(3, fop1, sop1)],
+                ("s1",): [(2, sop1)],
+            }
+        ) # 3*(fop1 @ sop1) + 2*(sop1)
+
+
+    **Algebra**
+
+    This class supports the following basic arithmetic operations: addition, subtraction, scalar
+    multiplication, operator multiplication.
+    For example,
+
+    Addition
+
+    .. code-block:: python
+
+        fop1 = FermionicOp({"+_0 -_0": 1}) # Acting on Hilbert space "h1"
+        sop1 = SpinOp({"X_0 Y_0": 1}, num_spins=1) # Acting on Hilbert space "s1"
+        MixedOp({("h1",): [(5.0, fop1)]}) + MixedOp({("s1",): [(6.0, sop1)]})
+        # MixedOp({("h1",): [(5.0, fop1)], ("s1",): [(6.0, sop1)]})
+
+    Scalar multiplication
+
+    .. code-block:: python
+
+        fop1 = FermionicOp({"+_0 -_0": 1})
+        0.5 * MixedOp({("h1",): [(5.0, fop1)]})
+
+    Operator multiplication
+
+    .. code-block:: python
+
+        fop1 = FermionicOp({"+_0 -_0": 1}) # Acting on Hilbert space "h1"
+        sop1 = SpinOp({"X_0 Y_0": 1}, num_spins=1) # Acting on Hilbert space "s1"
+        MixedOp({("h1",): [(5.0, fop1)]}) @ MixedOp({("s1",): [(6.0, sop1)]})
+        # MixedOp({("h1", "s1"): [(30.0, fop1, sop1)]})
+
+    """
+
+    def __init__(self, data: dict[tuple[str], list[tuple[float, SparseLabelOp]]]):
+        self.data = deepcopy(data)
+
+    def __repr__(self, indentation_level=0) -> str:
+        out_str = "Mixed Op\n"
+        out_str += f"Nb terms = {len(self.data)}\n"
+        for active_indices, oplist in self.data.items():
+            for op_tuple in oplist:
+                coef, active_operators = op_tuple[0], op_tuple[1:]
+                out_str += f"- Coefficient: {coef:.02f}\n"
+
+                for index, op in zip(active_indices, active_operators):
+                    out_str += "" * indentation_level + f"{index}: {repr(op)}\n"
+
+                out_str += "\n"
+
+        return out_str
+
+    @staticmethod
+    def _tuple_prod(tup1: tuple[int, ...], tup2: tuple) -> tuple[float, ...]:
+        """Implements the composition of operator tuples representing tensor products of operators."""
+        new_coeff = tup1[0] * tup2[0]
+        new_op_tuple = tup1[1:] + tup2[1:]
+        return (new_coeff,) + new_op_tuple
+
+    @staticmethod
+    def _tuple_multiply(tup: tuple[int, ...], coef: float) -> tuple[float, ...]:
+        """Implements the dilation by a coefficient of an operator tuple representing a tensor product
+        of operators."""
+        new_coeff = tup[0] * coef
+        return (new_coeff,) + tup[1:]
+
+    @classmethod
+    def _distribute_on_tuples(
+        cls, method: Callable, op_left: MixedOp, op_right: MixedOp = None, **kwargs
+    ) -> MixedOp:
+        """Implements the distributions of a method to the tuples of operators representing the product
+        of operators."""
+        new_op_data: dict = {}
+        if op_right is None:
+            # Distribute method over all tuples.
+            for key, op_tuple_list in op_left.data.items():
+                new_op_data[key] = [method(op_tuple, **kwargs) for op_tuple in op_tuple_list]
+        else:
+            # Distribute method over all combinations of tuples from the first and second operators.
+            for (key1, op_tuple_list1), (key2, op_tuple_list2) in itertools.product(
+                op_left.data.items(), op_right.data.items()
+            ):
+                new_op_data[key1 + key2] = [
+                    method(op_tuple1, op_tuple2, **kwargs)
+                    for (op_tuple1, op_tuple2) in itertools.product(op_tuple_list1, op_tuple_list2)
+                ]
+
+        return MixedOp(new_op_data)
+
+    def _multiply(self, other: float) -> MixedOp:
+        """Return Operator multiplication of self and other.
+
+        Args:
+            other: the second ``MixedOp`` to multiply to the first.
+            qargs: UNUSED.
+
+        Returns:
+            The new multiplied ``MixedOp``.
+        """
+        return MixedOp._distribute_on_tuples(MixedOp._tuple_multiply, op_left=self, coef=other)
+
+    def _add(self, other: MixedOp, qargs: None = None) -> MixedOp:
+        """Return Operator addition of self and other.
+
+        Args:
+            other: the second ``MixedOp`` to add to the first.
+            qargs: UNUSED.
+
+        Returns:
+            The new summed ``MixedOp``.
+        """
+
+        sum_op = MixedOp(self.data)  # deepcopy
+        for key in other.data.keys():
+            # If the key for the composite Hilbert space already exists in the dictionary, then the
+            # addition is performed by appending the new operator to the corresponding list.
+            # Otherwise, the addition is performed by adding a new pair key, value to the dictionary.
+            if key in sum_op.data.keys():
+                sum_op.data[key] += other.data[key]
+            else:
+                sum_op.data[key] = other.data[key]
+        return sum_op
+
+    @classmethod
+    def compose(cls, op_left: MixedOp, op_right: MixedOp) -> MixedOp:
+        """Returns Operator composition of self and other.
+
+        Args:
+            op_left: left MixedOp to tensor.
+            op_right: right MixedOp to tensor.
+
+        Returns:
+            The tensor product of left with right.
+        """
+
+        # Lazy composition without applying the products.
+        return MixedOp._distribute_on_tuples(
+            MixedOp._tuple_prod, op_left=op_left, op_right=op_right
+        )
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        return self.data == other.data

--- a/qiskit_nature/second_q/operators/mixed_op.py
+++ b/qiskit_nature/second_q/operators/mixed_op.py
@@ -23,7 +23,7 @@ from qiskit.quantum_info.operators.mixins import LinearMixin
 from .sparse_label_op import SparseLabelOp
 
 
-class MixedOp(LinearMixin):
+class MixedOp(LinearMixin, ABC):
     """Mixed operator.
 
     A ``MixedOp`` represents a weighted sum of products of fermionic/bosonic operators potentially

--- a/qiskit_nature/second_q/operators/mixed_op.py
+++ b/qiskit_nature/second_q/operators/mixed_op.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
+# (C) Copyright IBM 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -26,8 +26,8 @@ from .sparse_label_op import SparseLabelOp
 class MixedOp(LinearMixin):
     """Mixed operator.
 
-    A ``MixedOp`` represents a weighted sum of products of fermionic/bosonic operators potentially
-    acting on different "local" Hilbert spaces. The terms to be summed are encoded in a dictionary,
+    A ``MixedOp`` represents a weighted sum of products of operators such as fermionic, bosonic or spin
+    operators acting on respective Hilbert spaces. The terms to be summed are encoded in a dictionary,
     where each operator product is identified by its key, a tuple of string specifying the names of the
     local Hilbert spaces on which it acts, and by its value, a list of tuple (corresponding to a sum of
     operators acting on the same composite Hilbert space) where each tuple encodes the coupling
@@ -46,13 +46,16 @@ class MixedOp(LinearMixin):
         fop1 = FermionicOp({"+_0 -_0": 1}) # Acting on Hilbert space "h1"
         sop1 = SpinOp({"X_0 Y_0": 1}, num_spins=1) # Acting on Hilbert space "s1"
 
-        mop1 = MixedOp({("h1",): [(5.0, fop1)]}) # 5.0 * fop1
+        mop1 = MixedOp({("h1",): [(5.0, fop1)]})
         mop2 = MixedOp(
             {
                 ("h1", "s1"): [(3, fop1, sop1)],
                 ("s1",): [(2, sop1)],
             }
-        ) # 3*(fop1 @ sop1) + 2*(sop1)
+        )
+        # 5.0 * fop1 (acts as identity on the spin Hilbert space)
+        # 3*(fop1 @ sop1) (fermion-spin coupling term)
+        # 2*(sop1) (acts as identity on the fermionic Hilbert space)
 
 
     **Algebra**
@@ -148,7 +151,6 @@ class MixedOp(LinearMixin):
 
         Args:
             other: the second ``MixedOp`` to multiply to the first.
-            qargs: UNUSED.
 
         Returns:
             The new multiplied ``MixedOp``.
@@ -179,7 +181,7 @@ class MixedOp(LinearMixin):
 
     @classmethod
     def compose(cls, op_left: MixedOp, op_right: MixedOp) -> MixedOp:
-        """Returns Operator composition of self and other.
+        """Returns Operator composition of two mixed operators.
 
         Args:
             op_left: left MixedOp to tensor.

--- a/qiskit_nature/second_q/operators/mixed_op.py
+++ b/qiskit_nature/second_q/operators/mixed_op.py
@@ -23,7 +23,7 @@ from qiskit.quantum_info.operators.mixins import LinearMixin
 from .sparse_label_op import SparseLabelOp
 
 
-class MixedOp(LinearMixin, ABC):
+class MixedOp(LinearMixin):
     """Mixed operator.
 
     A ``MixedOp`` represents a weighted sum of products of fermionic/bosonic operators potentially
@@ -109,6 +109,7 @@ class MixedOp(LinearMixin, ABC):
     @staticmethod
     def _tuple_prod(tup1: tuple[int, ...], tup2: tuple) -> tuple[float, ...]:
         """Implements the composition of operator tuples representing tensor products of operators."""
+        print(tup1, tup2)
         new_coeff = tup1[0] * tup2[0]
         new_op_tuple = tup1[1:] + tup2[1:]
         return (new_coeff,) + new_op_tuple

--- a/qiskit_nature/second_q/operators/mixed_op.py
+++ b/qiskit_nature/second_q/operators/mixed_op.py
@@ -109,7 +109,6 @@ class MixedOp(LinearMixin):
     @staticmethod
     def _tuple_prod(tup1: tuple[int, ...], tup2: tuple) -> tuple[float, ...]:
         """Implements the composition of operator tuples representing tensor products of operators."""
-        print(tup1, tup2)
         new_coeff = tup1[0] * tup2[0]
         new_op_tuple = tup1[1:] + tup2[1:]
         return (new_coeff,) + new_op_tuple

--- a/releasenotes/notes/introduce-mixedop-and-mixed-mapper-46f0ef30314c71c0.yaml
+++ b/releasenotes/notes/introduce-mixedop-and-mixed-mapper-46f0ef30314c71c0.yaml
@@ -1,0 +1,49 @@
+---
+features:
+  - |
+    The classes :class:`.second_q.mappers.MixedMapper` and :class:`.second_q.operators.MixedOp` have been added
+    for manipulating composite systems. These class allow for dealing with Hamiltonians composed of
+    boson-fermion interactions.
+    
+    Below is an example of how one can use this mapper:
+
+    .. code-block:: python
+      
+      import numpy as np
+      from qiskit_nature.second_q.mappers.mixed_mapper import MixedMapper
+      from qiskit_nature.second_q.mappers import JordanWignerMapper, BosonicLinearMapper
+      from qiskit_nature.second_q.operators import FermionicOp, BosonicOp, MixedOp, PolynomialTensor
+
+      # Define mixed operator with a pure fermionic part and a bosonic part
+      ev_to_hartree = 0.0367492929
+
+      epsilonKS_mat = (np.diag([-9.965680, 3.027931, 5.816614, 5.816670, 8.888777]) * ev_to_hartree)
+      hel_data = {"+-": epsilonKS_mat}
+      hel_tensor = PolynomialTensor(hel_data)
+      hel_operator = FermionicOp.from_polynomial_tensor(hel_tensor)
+
+      hph_operator = BosonicOp(
+      {
+          "": 1 / 2,
+          "+_0 -_0": 1.0,
+      },
+      num_modes=1,
+      )
+
+      hqed_operator = MixedOp(
+      {
+          ("F",): [(1.0, hel_operator)],
+          ("B",): [(2.0, hph_operator)]
+      }
+      )
+
+      # Map mixed operator to qubit space
+      jw_mapper = JordanWignerMapper()
+      bl_mapper = BosonicLinearMapper(max_occupation=2) # 1 photon mode and 3 fock states
+      mappers = {"F": jw_mapper, "B": bl_mapper}
+      hilbert_space_registers = {"F": 5, "B": 3} # Actual qubit register size
+      # Careful that the bl_mapper requires register_length*(max_occupation+1) registers
+      mixed_mapper = MixedMapper(mappers, hilbert_space_registers)
+
+      hqed_operator_mapped = mixed_mapper.map(hqed_operator)
+

--- a/releasenotes/notes/introduce-mixedop-and-mixed-mapper-46f0ef30314c71c0.yaml
+++ b/releasenotes/notes/introduce-mixedop-and-mixed-mapper-46f0ef30314c71c0.yaml
@@ -2,8 +2,8 @@
 features:
   - |
     The classes :class:`.second_q.mappers.MixedMapper` and :class:`.second_q.operators.MixedOp` have been added
-    for manipulating composite systems. These class allow for dealing with Hamiltonians composed of
-    boson-fermion interactions.
+    for manipulating composite systems. These classes allow the treatment of Hamiltonians containing operators
+    associated with different particles (e.g. fermions and bosons).
     
     Below is an example of how one can use this mapper:
 
@@ -23,27 +23,27 @@ features:
       hel_operator = FermionicOp.from_polynomial_tensor(hel_tensor)
 
       hph_operator = BosonicOp(
-      {
-          "": 1 / 2,
-          "+_0 -_0": 1.0,
-      },
-      num_modes=1,
+        {
+            "": 1 / 2,
+            "+_0 -_0": 1.0,
+        },
+        num_modes=1,
       )
 
       hqed_operator = MixedOp(
-      {
-          ("F",): [(1.0, hel_operator)],
-          ("B",): [(2.0, hph_operator)]
-      }
+        {
+            ("F",): [(1.0, hel_operator)],
+            ("B",): [(2.0, hph_operator)]
+        }
       )
 
       # Map mixed operator to qubit space
       jw_mapper = JordanWignerMapper()
       bl_mapper = BosonicLinearMapper(max_occupation=2) # 1 photon mode and 3 fock states
       mappers = {"F": jw_mapper, "B": bl_mapper}
-      hilbert_space_registers = {"F": 5, "B": 3} # Actual qubit register size
+      hilbert_space_registers = {"F": 5, "B": 1} # 5 fermionic modes and 3 bosonic modes
       # Careful that the bl_mapper requires register_length*(max_occupation+1) registers
-      mixed_mapper = MixedMapper(mappers, hilbert_space_registers)
-
+      hilbert_space_register_types = {"b1": BosonicOp, "f1": FermionicOp}
+      mixed_mapper = MixedMapper(mappers, hilbert_space_registers, hilbert_space_register_types)
       hqed_operator_mapped = mixed_mapper.map(hqed_operator)
 

--- a/test/second_q/mappers/test_mixed_mapper.py
+++ b/test/second_q/mappers/test_mixed_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2024.
+# (C) Copyright IBM 2023, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/mappers/test_mixed_mapper.py
+++ b/test/second_q/mappers/test_mixed_mapper.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Mixed Mapper """
+"""Test Mixed Mapper"""
 
 import unittest
 
@@ -104,6 +104,22 @@ class TestMixedMapper(QiskitNatureTestCase):
             self.assertTrue(
                 calc_op_list[0].equiv(calc_op_dict["A"])
                 and calc_op_list[1].equiv(calc_op_dict["B"])
+            )
+
+    def test_map_multiple_fermionic_operators(self):
+        """Test the ``MixedOp`` mapping on list and dictionaries."""
+
+        with self.assertRaises(ValueError):
+
+            fer_mapper_1 = JordanWignerMapper()
+            fer_mapper_2 = JordanWignerMapper()
+            mappers = {"f2": fer_mapper_2, "f1": fer_mapper_1}
+            hilbert_space_register_lengths = {"f2": 1, "f1": 1}
+            hilbert_space_register_types = {"f2": FermionicOp, "f1": FermionicOp}
+            MixedMapper(
+                mappers=mappers,
+                hilbert_space_register_lengths=hilbert_space_register_lengths,
+                hilbert_space_register_types=hilbert_space_register_types,
             )
 
 

--- a/test/second_q/mappers/test_mixed_mapper.py
+++ b/test/second_q/mappers/test_mixed_mapper.py
@@ -1,0 +1,108 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2023, 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+""" Test Mixed Mapper """
+
+import unittest
+
+
+from test import QiskitNatureTestCase
+
+from ddt import ddt, data, unpack
+import numpy as np
+
+from qiskit.quantum_info import SparsePauliOp
+from qiskit_nature.second_q.operators import BosonicOp, FermionicOp, MixedOp
+from qiskit_nature.second_q.mappers import (
+    BosonicLinearMapper,
+    JordanWignerMapper,
+    MixedMapper,
+)
+
+
+@ddt
+class TestMixedMapper(QiskitNatureTestCase):
+    """Test Mixed Mapper"""
+
+    # Define some useful coefficients
+    sq_2 = np.sqrt(2)
+
+    bos_op1 = BosonicOp({"+_0": 1})
+    mapped_bos_op1 = SparsePauliOp(["XX", "YY", "YX", "XY"], coeffs=[0.25, 0.25, -0.25j, 0.25j])
+
+    bos_op2 = BosonicOp({"-_0": 1})
+    mapped_bos_op2 = SparsePauliOp(["XX", "YY", "YX", "XY"], coeffs=[0.25, 0.25, 0.25j, -0.25j])
+
+    fer_op1 = FermionicOp({"+_0": 1}, num_spin_orbitals=1)
+    mapped_fer_op1 = SparsePauliOp.from_list([("X", 0.5), ("Y", -0.5j)])
+
+    fer_op2 = FermionicOp({"-_0": 1}, num_spin_orbitals=1)
+    mapped_fer_op2 = SparsePauliOp.from_list([("X", 0.5), ("Y", 0.5j)])
+
+    bos_op5 = BosonicOp({"+_0 -_0": 1})
+    bos_op6 = BosonicOp({"-_0 +_0": 1})
+
+    bos_mapper = BosonicLinearMapper(max_occupation=1)
+    fer_mapper = JordanWignerMapper()
+    mappers = {"b1": bos_mapper, "f1": fer_mapper}
+    hilbert_space_register_lengths = {"b1": 1, "f1": 1}
+    mix_mapper = MixedMapper(
+        mappers=mappers, hilbert_space_register_lengths=hilbert_space_register_lengths
+    )
+
+    @data(
+        (bos_op1, fer_op1, 2.0 + 1.0j),
+        (bos_op2, fer_op2, 3.0 + 2.0j),
+        (bos_op5, fer_op1, -4.0 - 3.0j),
+        (bos_op6, fer_op2, -5.0 + 4j),
+    )
+    @unpack
+    def test_relative_mapping(self, bos_op, fer_op, coef):
+        """Test the ``MixedOp`` mapping and compare to the composition of the mapped operators."""
+
+        mop = MixedOp({("b1", "f1"): [(coef, bos_op, fer_op)]})
+
+        target = coef * self.bos_mapper.map(bos_op).tensor(self.fer_mapper.map(fer_op))
+        test = self.mix_mapper.map(mop)
+        self.assertTrue(target.equiv(test))
+
+    @data(
+        (bos_op1, fer_op1, 2.0 + 1.0j),
+        (bos_op2, fer_op2, 3.0 + 2.0j),
+        (bos_op5, fer_op1, -4.0 - 3.0j),
+        (bos_op6, fer_op2, -5.0 + 4j),
+    )
+    @unpack
+    def test_map_list_or_dict(self, bos_op, fer_op, coef):
+        """Test the ``MixedOp`` mapping on list and dictionaries."""
+
+        mop_1 = MixedOp({("b1", "f1"): [(coef, bos_op, fer_op)]})
+        mop_2 = MixedOp({("b1", "f1"): [(coef, bos_op, fer_op)]})
+
+        calc_op_dict = self.mix_mapper.map({"A": mop_1, "B": mop_2})
+        calc_op_list = self.mix_mapper.map([mop_1, mop_2])
+
+        with self.subTest("Type dict"):
+            self.assertTrue(isinstance(calc_op_dict, dict))
+
+        with self.subTest("Type list"):
+            self.assertTrue(isinstance(calc_op_list, list))
+
+        with self.subTest("Value"):
+            self.assertTrue(
+                calc_op_list[0].equiv(calc_op_dict["A"])
+                and calc_op_list[1].equiv(calc_op_dict["B"])
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/second_q/mappers/test_mixed_mapper.py
+++ b/test/second_q/mappers/test_mixed_mapper.py
@@ -107,7 +107,7 @@ class TestMixedMapper(QiskitNatureTestCase):
             )
 
     def test_map_multiple_fermionic_operators(self):
-        """Test the ``MixedOp`` mapping on list and dictionaries."""
+        """Test the ``MixedMapper`` if multiple fermionic operators are provided."""
 
         with self.assertRaises(ValueError):
 

--- a/test/second_q/mappers/test_mixed_mapper.py
+++ b/test/second_q/mappers/test_mixed_mapper.py
@@ -74,7 +74,7 @@ class TestMixedMapper(QiskitNatureTestCase):
 
         mop = MixedOp({("b1", "f1"): [(coef, bos_op, fer_op)]})
 
-        target = coef * self.bos_mapper.map(bos_op).tensor(self.fer_mapper.map(fer_op))
+        target = coef * self.fer_mapper.map(fer_op).tensor(self.bos_mapper.map(bos_op))
         test = self.mix_mapper.map(mop)
         self.assertTrue(target.equiv(test))
 

--- a/test/second_q/mappers/test_mixed_mapper.py
+++ b/test/second_q/mappers/test_mixed_mapper.py
@@ -55,8 +55,11 @@ class TestMixedMapper(QiskitNatureTestCase):
     fer_mapper = JordanWignerMapper()
     mappers = {"b1": bos_mapper, "f1": fer_mapper}
     hilbert_space_register_lengths = {"b1": 1, "f1": 1}
+    hilbert_space_register_types = {"b1": BosonicOp, "f1": FermionicOp}
     mix_mapper = MixedMapper(
-        mappers=mappers, hilbert_space_register_lengths=hilbert_space_register_lengths
+        mappers=mappers,
+        hilbert_space_register_lengths=hilbert_space_register_lengths,
+        hilbert_space_register_types=hilbert_space_register_types,
     )
 
     @data(

--- a/test/second_q/mappers/test_mixed_mapper.py
+++ b/test/second_q/mappers/test_mixed_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2025.
+# (C) Copyright IBM 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is part of a Qiskit project.
 #
 # (C) Copyright IBM 2021, 2023.
 #

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -145,8 +145,8 @@ class TestFermionicOp(QiskitNatureTestCase):
                 (
                     "h1",
                     "h2",
-                ): [(3.0 +2j, self.op1, self.op2)],
-                "h2": [(4.0 -5j, self.op2)],
+                ): [(3.0 + 2j, self.op1, self.op2)],
+                "h2": [(4.0 - 5j, self.op2)],
             }
         ).adjoint()
 
@@ -156,8 +156,8 @@ class TestFermionicOp(QiskitNatureTestCase):
                 (
                     "h1",
                     "h2",
-                ): [(3.0 -2j, self.op1.adjoint(), self.op2.adjoint())],
-                "h2": [(4.0 +5j, self.op2.adjoint())],
+                ): [(3.0 - 2j, self.op1.adjoint(), self.op2.adjoint())],
+                "h2": [(4.0 + 5j, self.op2.adjoint())],
             }
         )
         self.assertEqual(test_adjoint, targ_adjoint)
@@ -170,8 +170,8 @@ class TestFermionicOp(QiskitNatureTestCase):
                 (
                     "h1",
                     "h2",
-                ): [(3.0 +2j, self.op1, self.op2)],
-                "h2": [(4.0 -5j, self.op2)],
+                ): [(3.0 + 2j, self.op1, self.op2)],
+                "h2": [(4.0 - 5j, self.op2)],
             }
         ).conjugate()
 
@@ -181,8 +181,8 @@ class TestFermionicOp(QiskitNatureTestCase):
                 (
                     "h1",
                     "h2",
-                ): [(3.0 -2j, self.op1.conjugate(), self.op2.conjugate())],
-                "h2": [(4.0 +5j, self.op2.conjugate())],
+                ): [(3.0 - 2j, self.op1.conjugate(), self.op2.conjugate())],
+                "h2": [(4.0 + 5j, self.op2.conjugate())],
             }
         )
         self.assertEqual(test_conjugate, targ_conjugate)
@@ -195,8 +195,8 @@ class TestFermionicOp(QiskitNatureTestCase):
                 (
                     "h1",
                     "h2",
-                ): [(3.0 +2j, self.op1, self.op2)],
-                "h2": [(4.0 -5j, self.op2)],
+                ): [(3.0 + 2j, self.op1, self.op2)],
+                "h2": [(4.0 - 5j, self.op2)],
             }
         ).transpose()
 
@@ -211,6 +211,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             }
         )
         self.assertEqual(test_transpose, targ_transpose)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -118,89 +118,14 @@ class TestFermionicOp(QiskitNatureTestCase):
     def test_compose(self):
         """Test operator composition"""
         with self.subTest("same hilbert spaces"):
-            composed_op = self.mop1_h1.compose(self.mop2_h1)
+            composed_op = MixedOp.compose(self.mop1_h1, self.mop2_h1)
             target = MixedOp({("h1", "h1"): [(6.0, self.op1, self.op2)]})
             self.assertEqual(composed_op, target)
 
         with self.subTest("different hilbert spaces"):
-            composed_op = self.mop1_h1.compose(self.mop2_h2)
+            composed_op = MixedOp.compose(self.mop1_h1, self.mop2_h2)
             target = MixedOp({("h1", "h2"): [(6.0, self.op1, self.op2)]})
-            self.assertEqual(composed_op, target)
-
-    def test_adjoint(self):
-        """Test adjoint method"""
-        test_adjoint = MixedOp(
-            {
-                ("h1",): [(2.0 + 1j, self.op1)],
-                (
-                    "h1",
-                    "h2",
-                ): [(3.0 + 2j, self.op1, self.op2)],
-                "h2": [(4.0 - 5j, self.op2)],
-            }
-        ).adjoint()
-
-        target_adjoint = MixedOp(
-            {
-                ("h1",): [(2.0 - 1j, self.op1.adjoint())],
-                (
-                    "h1",
-                    "h2",
-                ): [(3.0 - 2j, self.op1.adjoint(), self.op2.adjoint())],
-                "h2": [(4.0 + 5j, self.op2.adjoint())],
-            }
-        )
-        self.assertEqual(test_adjoint, target_adjoint)
-
-    def test_conjugate(self):
-        """Test conjugate method"""
-        test_conjugate = MixedOp(
-            {
-                ("h1",): [(2.0 + 1j, self.op1)],
-                (
-                    "h1",
-                    "h2",
-                ): [(3.0 + 2j, self.op1, self.op2)],
-                "h2": [(4.0 - 5j, self.op2)],
-            }
-        ).conjugate()
-
-        target_conjugate = MixedOp(
-            {
-                ("h1",): [(2.0 - 1j, self.op1.conjugate())],
-                (
-                    "h1",
-                    "h2",
-                ): [(3.0 - 2j, self.op1.conjugate(), self.op2.conjugate())],
-                "h2": [(4.0 + 5j, self.op2.conjugate())],
-            }
-        )
-        self.assertEqual(test_conjugate, target_conjugate)
-
-    def test_transpose(self):
-        """Test transpose method"""
-        test_transpose = MixedOp(
-            {
-                ("h1",): [(2.0 + 1j, self.op1)],
-                (
-                    "h1",
-                    "h2",
-                ): [(3.0 + 2j, self.op1, self.op2)],
-                "h2": [(4.0 - 5j, self.op2)],
-            }
-        ).transpose()
-
-        target_transpose = MixedOp(
-            {
-                ("h1",): [(2.0 + 1j, self.op1.transpose())],
-                (
-                    "h1",
-                    "h2",
-                ): [(3.0 + 2j, self.op1.transpose(), self.op2.transpose())],
-                "h2": [(4.0 - 5j, self.op2.transpose())],
-            }
-        )
-        self.assertEqual(test_transpose, target_transpose)
+            # self.assertEqual(composed_op, target)
 
 
 if __name__ == "__main__":

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2025.
+# (C) Copyright IBM 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 from test import QiskitNatureTestCase
-from ddt import ddt
 
 from qiskit_nature.second_q.operators import FermionicOp, MixedOp
 

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -14,6 +14,7 @@
 
 import unittest
 from test import QiskitNatureTestCase
+from ddt import ddt
 
 from qiskit_nature.second_q.operators import FermionicOp, MixedOp
 

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -89,6 +89,5 @@ class TestFermionicOp(QiskitNatureTestCase):
             self.assertEqual(composed_op, target)
 
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -14,12 +14,10 @@
 
 import unittest
 from test import QiskitNatureTestCase
-from ddt import ddt
 
 from qiskit_nature.second_q.operators import FermionicOp, MixedOp
 
 
-@ddt
 class TestFermionicOp(QiskitNatureTestCase):
     """FermionicOp tests."""
 
@@ -36,14 +34,6 @@ class TestFermionicOp(QiskitNatureTestCase):
         target_v1 = MixedOp({("h1",): [(-2.0, self.op1)]})
         self.assertEqual(minus_mop1, target_v1)
 
-        # Requires the simplify()
-        # target_v2 = MixedOp({("h1",): [(2.0, -self.op1)]})
-        # self.assertEqual(minus_mop1, target_v2)
-
-        # fer_op = -self.op4
-        # target = FermionicOp({"+_0 -_0": -self.a})
-        # self.assertEqual(fer_op, target)
-
     def test_mul(self):
         """Test __mul__, and __rmul__"""
         with self.subTest("rightmul"):
@@ -51,32 +41,16 @@ class TestFermionicOp(QiskitNatureTestCase):
             target_v1 = MixedOp({("h1",): [(4.0, self.op1)]})
             self.assertEqual(minus_mop1, target_v1)
 
-            # target_v2 = MixedOp({("h1",): [(2.0, 2.0 * self.op1)]})
-            # self.assertEqual(minus_mop1, target_v2)
-
-            # Requires the simplify()
-            # fer_op = self.op1 * self.a
-            # target = FermionicOp({"+_0 -_0": self.a})
-            # self.assertEqual(fer_op, target)
-
         with self.subTest("leftmul"):
             minus_mop1 = (2.0 + 1.0j) * self.mop1_h1
             target_v1 = MixedOp({("h1",): [((4.0 + 2.0j), self.op1)]})
             self.assertEqual(minus_mop1, target_v1)
 
-            # Requires the simplify()
-            # target_v2 = MixedOp({("h1",): [(2.0, (2.0 + 1.0j) * self.op1)]})
-            # self.assertEqual(minus_mop1, target_v2)
-
-    # def test_div(self):
-    #     """Test __truediv__"""
-    #     fer_op = self.op1 / 2
-    #     target = FermionicOp({"+_0 -_0": 0.5}, num_spin_orbitals=1)
-    #     self.assertEqual(fer_op, target)
-
-    #     fer_op = self.op1 / self.a
-    #     target = FermionicOp({"+_0 -_0": 1 / self.a})
-    #     self.assertEqual(fer_op, target)
+    def test_div(self):
+        """Test __truediv__"""
+        fer_op = self.op1 / 2
+        target = FermionicOp({"+_0 -_0": 0.5}, num_spin_orbitals=1)
+        self.assertEqual(fer_op, target)
 
     def test_add(self):
         """Test __add__"""
@@ -85,19 +59,10 @@ class TestFermionicOp(QiskitNatureTestCase):
             target = MixedOp({("h1",): [(2, self.op1), (3, self.op2)]})
             self.assertEqual(sum_mop, target)
 
-            # Requires the simplify()
-            # target = self.sumop2
-            # self.assertEqual(sum_mop, target)
-
         with self.subTest("different hilbert space"):
             sum_mop = self.mop1_h1 + self.mop2_h2
             target = MixedOp({("h1",): [(2.0, self.op1)], ("h2",): [(3.0, self.op2)]})
             self.assertEqual(sum_mop, target)
-
-        # with self.subTest("sum"):
-        #     fer_op = sum(FermionicOp({label: 1}) for label in ["+_0", "-_1", "+_2 -_2"])
-        #     target = FermionicOp({"+_0": 1, "-_1": 1, "+_2 -_2": 1})
-        #     self.assertEqual(fer_op, target)
 
     def test_sub(self):
         """Test __sub__"""
@@ -105,10 +70,6 @@ class TestFermionicOp(QiskitNatureTestCase):
             sum_mop = self.mop1_h1 - self.mop2_h1
             target = MixedOp({("h1",): [(2, self.op1), (-3, self.op2)]})
             self.assertEqual(sum_mop, target)
-
-            # Requires the simplify()
-            # target = self.sumop2
-            # self.assertEqual(sum_mop, target)
 
         with self.subTest("different hilbert space"):
             sum_mop = self.mop1_h1 - self.mop2_h2
@@ -125,7 +86,7 @@ class TestFermionicOp(QiskitNatureTestCase):
         with self.subTest("different hilbert spaces"):
             composed_op = MixedOp.compose(self.mop1_h1, self.mop2_h2)
             target = MixedOp({("h1", "h2"): [(6.0, self.op1, self.op2)]})
-            # self.assertEqual(composed_op, target)
+            self.assertEqual(composed_op, target)
 
 
 if __name__ == "__main__":

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -89,5 +89,6 @@ class TestFermionicOp(QiskitNatureTestCase):
             self.assertEqual(composed_op, target)
 
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -1,0 +1,216 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test for MixedOp"""
+
+import unittest
+import warnings
+from test import QiskitNatureTestCase
+
+import numpy as np
+from ddt import data, ddt, unpack
+from qiskit.circuit import Parameter
+from scipy.sparse import csc_matrix
+from scipy.sparse.linalg import eigs
+
+from qiskit_nature.exceptions import QiskitNatureError
+from qiskit_nature.second_q.operators import FermionicOp, MixedOp
+import qiskit_nature.optionals as _optionals
+
+from qiskit_nature import settings
+
+
+@ddt
+class TestFermionicOp(QiskitNatureTestCase):
+    """FermionicOp tests."""
+
+    op1 = FermionicOp({"+_0 -_0": 1})
+    op2 = FermionicOp({"-_0 +_0": 2})
+    mop1_h1 = MixedOp({("h1",): [(2.0, op1)]})
+    mop2_h1 = MixedOp({("h1",): [(3.0, op2)]})
+    mop2_h2 = MixedOp({("h2",): [(3.0, op2)]})
+    sumop2 = MixedOp({("h1",): [(1, FermionicOp({"+_0 -_0": 2, "-_0 +_0": 3}))]})
+
+    def test_neg(self):
+        """Test __neg__"""
+        minus_mop1 = -self.mop1_h1
+        targ_v1 = MixedOp({("h1",): [(-2.0, self.op1)]})
+        self.assertEqual(minus_mop1, targ_v1)
+
+        # Requires the simplify()
+        # targ_v2 = MixedOp({("h1",): [(2.0, -self.op1)]})
+        # self.assertEqual(minus_mop1, targ_v2)
+
+        # fer_op = -self.op4
+        # targ = FermionicOp({"+_0 -_0": -self.a})
+        # self.assertEqual(fer_op, targ)
+
+    def test_mul(self):
+        """Test __mul__, and __rmul__"""
+        with self.subTest("rightmul"):
+            minus_mop1 = self.mop1_h1 * 2.0
+            targ_v1 = MixedOp({("h1",): [(4.0, self.op1)]})
+            self.assertEqual(minus_mop1, targ_v1)
+
+            # targ_v2 = MixedOp({("h1",): [(2.0, 2.0 * self.op1)]})
+            # self.assertEqual(minus_mop1, targ_v2)
+
+            # Requires the simplify()
+            # fer_op = self.op1 * self.a
+            # targ = FermionicOp({"+_0 -_0": self.a})
+            # self.assertEqual(fer_op, targ)
+
+        with self.subTest("leftmul"):
+            minus_mop1 = (2.0 + 1.0j) * self.mop1_h1
+            targ_v1 = MixedOp({("h1",): [((4.0 + 2.0j), self.op1)]})
+            self.assertEqual(minus_mop1, targ_v1)
+
+            # Requires the simplify()
+            # targ_v2 = MixedOp({("h1",): [(2.0, (2.0 + 1.0j) * self.op1)]})
+            # self.assertEqual(minus_mop1, targ_v2)
+
+    # def test_div(self):
+    #     """Test __truediv__"""
+    #     fer_op = self.op1 / 2
+    #     targ = FermionicOp({"+_0 -_0": 0.5}, num_spin_orbitals=1)
+    #     self.assertEqual(fer_op, targ)
+
+    #     fer_op = self.op1 / self.a
+    #     targ = FermionicOp({"+_0 -_0": 1 / self.a})
+    #     self.assertEqual(fer_op, targ)
+
+    def test_add(self):
+        """Test __add__"""
+        with self.subTest("same hilbert space"):
+            sum_mop = self.mop1_h1 + self.mop2_h1
+            targ = MixedOp({("h1",): [(2, self.op1), (3, self.op2)]})
+            self.assertEqual(sum_mop, targ)
+
+            # Requires the simplify()
+            # targ = self.sumop2
+            # self.assertEqual(sum_mop, targ)
+
+        with self.subTest("different hilbert space"):
+            sum_mop = self.mop1_h1 + self.mop2_h2
+            targ = MixedOp({("h1",): [(2.0, self.op1)], ("h2",): [(3.0, self.op2)]})
+            self.assertEqual(sum_mop, targ)
+
+        # with self.subTest("sum"):
+        #     fer_op = sum(FermionicOp({label: 1}) for label in ["+_0", "-_1", "+_2 -_2"])
+        #     targ = FermionicOp({"+_0": 1, "-_1": 1, "+_2 -_2": 1})
+        #     self.assertEqual(fer_op, targ)
+
+    def test_sub(self):
+        """Test __sub__"""
+        with self.subTest("same hilbert space"):
+            sum_mop = self.mop1_h1 - self.mop2_h1
+            targ = MixedOp({("h1",): [(2, self.op1), (-3, self.op2)]})
+            self.assertEqual(sum_mop, targ)
+
+            # Requires the simplify()
+            # targ = self.sumop2
+            # self.assertEqual(sum_mop, targ)
+
+        with self.subTest("different hilbert space"):
+            sum_mop = self.mop1_h1 - self.mop2_h2
+            targ = MixedOp({("h1",): [(2.0, self.op1)], ("h2",): [(-3.0, self.op2)]})
+            self.assertEqual(sum_mop, targ)
+
+    def test_compose(self):
+        """Test operator composition"""
+        with self.subTest("same hilbert spaces"):
+            composed_op = self.mop1_h1.compose(self.mop2_h1)
+            targ = MixedOp({("h1", "h1"): [(6.0, self.op1, self.op2)]})
+            self.assertEqual(composed_op, targ)
+
+        with self.subTest("different hilbert spaces"):
+            composed_op = self.mop1_h1.compose(self.mop2_h2)
+            targ = MixedOp({("h1", "h2"): [(6.0, self.op1, self.op2)]})
+            self.assertEqual(composed_op, targ)
+
+    def test_adjoint(self):
+        """Test adjoint method"""
+        test_adjoint = MixedOp(
+            {
+                ("h1",): [(2.0 + 1j, self.op1)],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 +2j, self.op1, self.op2)],
+                "h2": [(4.0 -5j, self.op2)],
+            }
+        ).adjoint()
+
+        targ_adjoint = MixedOp(
+            {
+                ("h1",): [(2.0 - 1j, self.op1.adjoint())],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 -2j, self.op1.adjoint(), self.op2.adjoint())],
+                "h2": [(4.0 +5j, self.op2.adjoint())],
+            }
+        )
+        self.assertEqual(test_adjoint, targ_adjoint)
+
+    def test_conjugate(self):
+        """Test conjugate method"""
+        test_conjugate = MixedOp(
+            {
+                ("h1",): [(2.0 + 1j, self.op1)],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 +2j, self.op1, self.op2)],
+                "h2": [(4.0 -5j, self.op2)],
+            }
+        ).conjugate()
+
+        targ_conjugate = MixedOp(
+            {
+                ("h1",): [(2.0 - 1j, self.op1.conjugate())],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 -2j, self.op1.conjugate(), self.op2.conjugate())],
+                "h2": [(4.0 +5j, self.op2.conjugate())],
+            }
+        )
+        self.assertEqual(test_conjugate, targ_conjugate)
+
+    def test_transpose(self):
+        """Test transpose method"""
+        test_transpose = MixedOp(
+            {
+                ("h1",): [(2.0 + 1j, self.op1)],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 +2j, self.op1, self.op2)],
+                "h2": [(4.0 -5j, self.op2)],
+            }
+        ).transpose()
+
+        targ_transpose = MixedOp(
+            {
+                ("h1",): [(2.0 + 1j, self.op1.transpose())],
+                (
+                    "h1",
+                    "h2",
+                ): [(3.0 + 2j, self.op1.transpose(), self.op2.transpose())],
+                "h2": [(4.0 - 5j, self.op2.transpose())],
+            }
+        )
+        self.assertEqual(test_transpose, targ_transpose)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -43,99 +43,99 @@ class TestFermionicOp(QiskitNatureTestCase):
     def test_neg(self):
         """Test __neg__"""
         minus_mop1 = -self.mop1_h1
-        targ_v1 = MixedOp({("h1",): [(-2.0, self.op1)]})
-        self.assertEqual(minus_mop1, targ_v1)
+        target_v1 = MixedOp({("h1",): [(-2.0, self.op1)]})
+        self.assertEqual(minus_mop1, target_v1)
 
         # Requires the simplify()
-        # targ_v2 = MixedOp({("h1",): [(2.0, -self.op1)]})
-        # self.assertEqual(minus_mop1, targ_v2)
+        # target_v2 = MixedOp({("h1",): [(2.0, -self.op1)]})
+        # self.assertEqual(minus_mop1, target_v2)
 
         # fer_op = -self.op4
-        # targ = FermionicOp({"+_0 -_0": -self.a})
-        # self.assertEqual(fer_op, targ)
+        # target = FermionicOp({"+_0 -_0": -self.a})
+        # self.assertEqual(fer_op, target)
 
     def test_mul(self):
         """Test __mul__, and __rmul__"""
         with self.subTest("rightmul"):
             minus_mop1 = self.mop1_h1 * 2.0
-            targ_v1 = MixedOp({("h1",): [(4.0, self.op1)]})
-            self.assertEqual(minus_mop1, targ_v1)
+            target_v1 = MixedOp({("h1",): [(4.0, self.op1)]})
+            self.assertEqual(minus_mop1, target_v1)
 
-            # targ_v2 = MixedOp({("h1",): [(2.0, 2.0 * self.op1)]})
-            # self.assertEqual(minus_mop1, targ_v2)
+            # target_v2 = MixedOp({("h1",): [(2.0, 2.0 * self.op1)]})
+            # self.assertEqual(minus_mop1, target_v2)
 
             # Requires the simplify()
             # fer_op = self.op1 * self.a
-            # targ = FermionicOp({"+_0 -_0": self.a})
-            # self.assertEqual(fer_op, targ)
+            # target = FermionicOp({"+_0 -_0": self.a})
+            # self.assertEqual(fer_op, target)
 
         with self.subTest("leftmul"):
             minus_mop1 = (2.0 + 1.0j) * self.mop1_h1
-            targ_v1 = MixedOp({("h1",): [((4.0 + 2.0j), self.op1)]})
-            self.assertEqual(minus_mop1, targ_v1)
+            target_v1 = MixedOp({("h1",): [((4.0 + 2.0j), self.op1)]})
+            self.assertEqual(minus_mop1, target_v1)
 
             # Requires the simplify()
-            # targ_v2 = MixedOp({("h1",): [(2.0, (2.0 + 1.0j) * self.op1)]})
-            # self.assertEqual(minus_mop1, targ_v2)
+            # target_v2 = MixedOp({("h1",): [(2.0, (2.0 + 1.0j) * self.op1)]})
+            # self.assertEqual(minus_mop1, target_v2)
 
     # def test_div(self):
     #     """Test __truediv__"""
     #     fer_op = self.op1 / 2
-    #     targ = FermionicOp({"+_0 -_0": 0.5}, num_spin_orbitals=1)
-    #     self.assertEqual(fer_op, targ)
+    #     target = FermionicOp({"+_0 -_0": 0.5}, num_spin_orbitals=1)
+    #     self.assertEqual(fer_op, target)
 
     #     fer_op = self.op1 / self.a
-    #     targ = FermionicOp({"+_0 -_0": 1 / self.a})
-    #     self.assertEqual(fer_op, targ)
+    #     target = FermionicOp({"+_0 -_0": 1 / self.a})
+    #     self.assertEqual(fer_op, target)
 
     def test_add(self):
         """Test __add__"""
         with self.subTest("same hilbert space"):
             sum_mop = self.mop1_h1 + self.mop2_h1
-            targ = MixedOp({("h1",): [(2, self.op1), (3, self.op2)]})
-            self.assertEqual(sum_mop, targ)
+            target = MixedOp({("h1",): [(2, self.op1), (3, self.op2)]})
+            self.assertEqual(sum_mop, target)
 
             # Requires the simplify()
-            # targ = self.sumop2
-            # self.assertEqual(sum_mop, targ)
+            # target = self.sumop2
+            # self.assertEqual(sum_mop, target)
 
         with self.subTest("different hilbert space"):
             sum_mop = self.mop1_h1 + self.mop2_h2
-            targ = MixedOp({("h1",): [(2.0, self.op1)], ("h2",): [(3.0, self.op2)]})
-            self.assertEqual(sum_mop, targ)
+            target = MixedOp({("h1",): [(2.0, self.op1)], ("h2",): [(3.0, self.op2)]})
+            self.assertEqual(sum_mop, target)
 
         # with self.subTest("sum"):
         #     fer_op = sum(FermionicOp({label: 1}) for label in ["+_0", "-_1", "+_2 -_2"])
-        #     targ = FermionicOp({"+_0": 1, "-_1": 1, "+_2 -_2": 1})
-        #     self.assertEqual(fer_op, targ)
+        #     target = FermionicOp({"+_0": 1, "-_1": 1, "+_2 -_2": 1})
+        #     self.assertEqual(fer_op, target)
 
     def test_sub(self):
         """Test __sub__"""
         with self.subTest("same hilbert space"):
             sum_mop = self.mop1_h1 - self.mop2_h1
-            targ = MixedOp({("h1",): [(2, self.op1), (-3, self.op2)]})
-            self.assertEqual(sum_mop, targ)
+            target = MixedOp({("h1",): [(2, self.op1), (-3, self.op2)]})
+            self.assertEqual(sum_mop, target)
 
             # Requires the simplify()
-            # targ = self.sumop2
-            # self.assertEqual(sum_mop, targ)
+            # target = self.sumop2
+            # self.assertEqual(sum_mop, target)
 
         with self.subTest("different hilbert space"):
             sum_mop = self.mop1_h1 - self.mop2_h2
-            targ = MixedOp({("h1",): [(2.0, self.op1)], ("h2",): [(-3.0, self.op2)]})
-            self.assertEqual(sum_mop, targ)
+            target = MixedOp({("h1",): [(2.0, self.op1)], ("h2",): [(-3.0, self.op2)]})
+            self.assertEqual(sum_mop, target)
 
     def test_compose(self):
         """Test operator composition"""
         with self.subTest("same hilbert spaces"):
             composed_op = self.mop1_h1.compose(self.mop2_h1)
-            targ = MixedOp({("h1", "h1"): [(6.0, self.op1, self.op2)]})
-            self.assertEqual(composed_op, targ)
+            target = MixedOp({("h1", "h1"): [(6.0, self.op1, self.op2)]})
+            self.assertEqual(composed_op, target)
 
         with self.subTest("different hilbert spaces"):
             composed_op = self.mop1_h1.compose(self.mop2_h2)
-            targ = MixedOp({("h1", "h2"): [(6.0, self.op1, self.op2)]})
-            self.assertEqual(composed_op, targ)
+            target = MixedOp({("h1", "h2"): [(6.0, self.op1, self.op2)]})
+            self.assertEqual(composed_op, target)
 
     def test_adjoint(self):
         """Test adjoint method"""
@@ -150,7 +150,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             }
         ).adjoint()
 
-        targ_adjoint = MixedOp(
+        target_adjoint = MixedOp(
             {
                 ("h1",): [(2.0 - 1j, self.op1.adjoint())],
                 (
@@ -160,7 +160,7 @@ class TestFermionicOp(QiskitNatureTestCase):
                 "h2": [(4.0 + 5j, self.op2.adjoint())],
             }
         )
-        self.assertEqual(test_adjoint, targ_adjoint)
+        self.assertEqual(test_adjoint, target_adjoint)
 
     def test_conjugate(self):
         """Test conjugate method"""
@@ -175,7 +175,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             }
         ).conjugate()
 
-        targ_conjugate = MixedOp(
+        target_conjugate = MixedOp(
             {
                 ("h1",): [(2.0 - 1j, self.op1.conjugate())],
                 (
@@ -185,7 +185,7 @@ class TestFermionicOp(QiskitNatureTestCase):
                 "h2": [(4.0 + 5j, self.op2.conjugate())],
             }
         )
-        self.assertEqual(test_conjugate, targ_conjugate)
+        self.assertEqual(test_conjugate, target_conjugate)
 
     def test_transpose(self):
         """Test transpose method"""
@@ -200,7 +200,7 @@ class TestFermionicOp(QiskitNatureTestCase):
             }
         ).transpose()
 
-        targ_transpose = MixedOp(
+        target_transpose = MixedOp(
             {
                 ("h1",): [(2.0 + 1j, self.op1.transpose())],
                 (
@@ -210,7 +210,7 @@ class TestFermionicOp(QiskitNatureTestCase):
                 "h2": [(4.0 - 5j, self.op2.transpose())],
             }
         )
-        self.assertEqual(test_transpose, targ_transpose)
+        self.assertEqual(test_transpose, target_transpose)
 
 
 if __name__ == "__main__":

--- a/test/second_q/operators/test_mixed_op.py
+++ b/test/second_q/operators/test_mixed_op.py
@@ -13,20 +13,10 @@
 """Test for MixedOp"""
 
 import unittest
-import warnings
 from test import QiskitNatureTestCase
+from ddt import ddt
 
-import numpy as np
-from ddt import data, ddt, unpack
-from qiskit.circuit import Parameter
-from scipy.sparse import csc_matrix
-from scipy.sparse.linalg import eigs
-
-from qiskit_nature.exceptions import QiskitNatureError
 from qiskit_nature.second_q.operators import FermionicOp, MixedOp
-import qiskit_nature.optionals as _optionals
-
-from qiskit_nature import settings
 
 
 @ddt


### PR DESCRIPTION
### Summary

Fix #795 

This draft PR introduces a MixedOp for manipulating systems corresponding to various "local" Hilbert spaces.
An implementation of the  MixedMapper for mapping this operator into a sum of qubit operators acting on the composed registers is also proposed.

Updated tutorial
[MixedOpTutorial.zip](https://github.com/user-attachments/files/18591759/MixedOpTutorial.zip)



