### PR TITLE
fix: typing compatibility with rustworkx 0.13.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,7 +217,14 @@ jobs:
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate psi4env
           make mypy
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.python-version != 3.7 }}
+        shell: bash
+      - name: Run mypy on Python 3.7
+        run: |
+          source "$CONDA/etc/profile.d/conda.sh"
+          conda activate psi4env
+          python -m mypy --no-warn-unused-ignores qiskit_nature test tools
+        if: ${{ !cancelled() && matrix.python-version == 3.7 }}
         shell: bash
       - name: Stestr Cache
         uses: actions/cache@v3

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,3 @@
 numpy>=1.20.0
 ipython<8.13;python_version<'3.9'
+rustworkx!=0.13.0;python_version<'3.8'

--- a/qiskit_nature/second_q/hamiltonians/lattices/hyper_cubic_lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/hyper_cubic_lattice.py
@@ -111,7 +111,7 @@ class HyperCubicLattice(Lattice):
 
         self._boundary_condition = boundary_condition
 
-        graph = PyGraph(multigraph=False)
+        graph: PyGraph = PyGraph(multigraph=False)
         graph.add_nodes_from(range(np.prod(size)))
 
         # add edges excluding the boundary edges

--- a/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
@@ -22,7 +22,7 @@ import numbers
 import numpy as np
 
 from rustworkx import NodeIndices, PyGraph, WeightedEdgeList
-from rustworkx import adjacency_matrix, networkx_converter
+from rustworkx import adjacency_matrix, networkx_converter  # type: ignore[attr-defined]
 from rustworkx.visualization import mpl_draw
 
 from qiskit.utils import optionals as _optionals
@@ -186,7 +186,7 @@ class Lattice:
         Returns:
             Lattice generated from lists of nodes and edges.
         """
-        graph = PyGraph(multigraph=False)
+        graph: PyGraph = PyGraph(multigraph=False)
         graph.add_nodes_from(range(num_nodes))
         graph.add_edges_from(weighted_edges)
         return cls(graph)
@@ -243,7 +243,7 @@ class Lattice:
                 "It must be a square matrix."
             )
 
-        graph = PyGraph(multigraph=False)
+        graph: PyGraph = PyGraph(multigraph=False)
         graph.add_nodes_from(range(shape[0]))
         for source_index in range(shape[0]):
             for target_index in range(source_index, shape[0]):

--- a/qiskit_nature/second_q/hamiltonians/lattices/triangular_lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/triangular_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/hamiltonians/lattices/triangular_lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/triangular_lattice.py
@@ -209,7 +209,7 @@ class TriangularLattice(Lattice):
         self.edge_parameter = edge_parameter
         self.onsite_parameter = onsite_parameter
 
-        graph = PyGraph(multigraph=False)
+        graph: PyGraph = PyGraph(multigraph=False)
         graph.add_nodes_from(range(np.prod(self.size)))
 
         # add edges excluding the boundary edges

--- a/test/second_q/hamiltonians/lattices/test_hyper_cubic_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_hyper_cubic_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/hamiltonians/lattices/test_hyper_cubic_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_hyper_cubic_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     HyperCubicLattice,

--- a/test/second_q/hamiltonians/lattices/test_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/hamiltonians/lattices/test_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_lattice.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from rustworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
 
 from qiskit.utils import optionals as _optionals
 

--- a/test/second_q/hamiltonians/lattices/test_line_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_line_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/hamiltonians/lattices/test_line_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_line_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     LineLattice,

--- a/test/second_q/hamiltonians/lattices/test_square_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_square_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/hamiltonians/lattices/test_square_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_square_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     SquareLattice,

--- a/test/second_q/hamiltonians/lattices/test_triangular_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_triangular_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/hamiltonians/lattices/test_triangular_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_triangular_lattice.py
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     TriangularLattice,

--- a/test/second_q/hamiltonians/test_fermi_hubbard_model.py
+++ b/test/second_q/hamiltonians/test_fermi_hubbard_model.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/hamiltonians/test_fermi_hubbard_model.py
+++ b/test/second_q/hamiltonians/test_fermi_hubbard_model.py
@@ -15,7 +15,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
 
 from qiskit_nature.second_q.hamiltonians import FermiHubbardModel
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice

--- a/test/second_q/hamiltonians/test_heisenberg_model.py
+++ b/test/second_q/hamiltonians/test_heisenberg_model.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/hamiltonians/test_heisenberg_model.py
+++ b/test/second_q/hamiltonians/test_heisenberg_model.py
@@ -13,7 +13,7 @@
 """Test HeisenbergModel."""
 
 from test import QiskitNatureTestCase
-from rustworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice, LineLattice
 from qiskit_nature.second_q.hamiltonians import HeisenbergModel, IsingModel
 

--- a/test/second_q/hamiltonians/test_ising_model.py
+++ b/test/second_q/hamiltonians/test_ising_model.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/hamiltonians/test_ising_model.py
+++ b/test/second_q/hamiltonians/test_ising_model.py
@@ -16,7 +16,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic
+from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
 
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice
 from qiskit_nature.second_q.hamiltonians import IsingModel


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Makes mypy happy due to the new typing support of rustworkx 0.13.0
So far, this is only a partial typing support which mypy does not seem to pick up on, despite https://github.com/Qiskit/rustworkx/blob/58fdd933cd81c576a3cc02c8a6b7b4e4646ea9c3/rustworkx/py.typed#L1

### Details and comments

The constraint for Python 3.7 is due to https://github.com/Qiskit/rustworkx/issues/893