### PR TITLE
Multi-Tensor splitting and stacking utilities

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -226,6 +226,8 @@ hijs
 hilbert
 histidine
 hjo
+hsplit
+hstack
 html
 https
 hubbard
@@ -629,6 +631,8 @@ vmax
 vmin
 vqe
 vscf
+vsplit
+vstack
 vwn
 vx
 vy

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -469,7 +469,7 @@ class ElectronicIntegrals(LinearMixin):
                 operands. This function must take a sequence of numpy (or sparse) arrays as its
                 first argument. You should use :code:`functools.partial` if you need to provide
                 keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`). Common methods to use
-                here are :meth:`np.hstack` and :meth:`np.vstack`.
+                here are :meth:`numpy.hstack` and :meth:`numpy.vstack`.
             operands: a sequence of ``ElectronicIntegrals`` instances on which to operate.
             validate: when set to False, no validation will be performed. Disable this setting with
                 care!
@@ -521,7 +521,7 @@ class ElectronicIntegrals(LinearMixin):
                 sparse) array as its first input followed by a sequence of indices to split on.
                 You should use :code:`functools.partial` if you need to provide keyword arguments
                 (e.g. :code:`partial(np.split, axis=-1)`). Common methods to use here are
-                :meth:`np.hsplit` and :meth:`np.vsplit`.
+                :meth:`numpy.hsplit` and :meth:`numpy.vsplit`.
             indices_or_sections: a single index or sequence of indices to split on.
             validate: when set to False, no validation will be performed. Disable this setting with
                 care!

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -463,7 +463,7 @@ class ElectronicIntegrals(LinearMixin):
                 operands. This function must take a sequence of numpy (or sparse) arrays as its
                 first argument. You should use :code:`functools.partial` if you need to provide
                 keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`). Common methods to use
-                here are ``np.hstack`` and ``np.vstack``.
+                here are :meth:`np.hstack` and :meth:`np.vstack`.
             operands: a sequence of ``ElectronicIntegrals`` instances on which to operate.
             validate: when set to False, no validation will be performed. Disable this setting with
                 care!
@@ -509,7 +509,7 @@ class ElectronicIntegrals(LinearMixin):
                 sparse) array as its first input followed by a sequence of indices to split on.
                 You should use :code:`functools.partial` if you need to provide keyword arguments
                 (e.g. :code:`partial(np.split, axis=-1)`). Common methods to use here are
-                ``np.hsplit`` and ``np.vsplit``.
+                :meth:`np.hsplit` and :meth:`np.vsplit`.
             indices_or_sections: a single index or sequence of indices to split on.
             validate: when set to False, no validation will be performed. Disable this setting with
                 care!

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -144,7 +144,8 @@ class ElectronicIntegrals(LinearMixin):
             beta: the down-spin electronic integrals
             beta_alpha: the beta-alpha-spin two-body electronic integrals. This may *only* contain
                 the ``++--`` key.
-            validate: when set to False, no validation will be performed.
+            validate: when set to False, no validation will be performed. Disable this setting with
+                care!
 
         Raises:
             KeyError: if the ``alpha`` tensor contains keys other than ``""``, ``"+-"``, and ``"++--"``.
@@ -411,7 +412,8 @@ class ElectronicIntegrals(LinearMixin):
                 function must take numpy (or sparse) arrays as its positional arguments. The number
                 of arguments must match the number of provided operands.
             operands: a sequence of ``ElectronicIntegrals`` instances on which to operate.
-            validate: when set to False, no validation will be performed.
+            validate: when set to False, no validation will be performed. Disable this setting with
+                care!
 
         Returns:
             A new ``ElectronicIntegrals``.
@@ -462,7 +464,8 @@ class ElectronicIntegrals(LinearMixin):
                 first argument. You should use :code:`functools.partial` if you need to provide
                 keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`)
             operands: a sequence of ``ElectronicIntegrals`` instances on which to operate.
-            validate: when set to False, no validation will be performed.
+            validate: when set to False, no validation will be performed. Disable this setting with
+                care!
 
         Returns:
             A new ``ElectronicIntegrals``.
@@ -506,7 +509,8 @@ class ElectronicIntegrals(LinearMixin):
                 You should use :code:`functools.partial` if you need to provide keyword arguments
                 (e.g. :code:`partial(np.split, axis=-1)`)
             indices_or_sections: a single index or sequence of indices to split on.
-            validate: when set to False, no validation will be performed.
+            validate: when set to False, no validation will be performed. Disable this setting with
+                care!
 
         Returns:
             The new ``ElectronicIntegrals`` instances.
@@ -555,7 +559,8 @@ class ElectronicIntegrals(LinearMixin):
                 provided ``ElectronicIntegrals`` operands. The last string in this tuple indicates
                 the key under which to store the result in the returned ``ElectronicIntegrals``.
             operands: a sequence of ``ElectronicIntegrals`` instances on which to operate.
-            validate: when set to False, no validation will be performed.
+            validate: when set to False, no validation will be performed. Disable this setting with
+                care!
 
         Returns:
             A new ``ElectronicIntegrals``.
@@ -609,7 +614,8 @@ class ElectronicIntegrals(LinearMixin):
             h1_b: the beta-spin one-body integrals.
             h2_bb: the beta-beta-spin two-body integrals.
             h2_ba: the beta-alpha-spin two-body integrals.
-            validate: whether or not to validate the integral matrices.
+            validate: whether or not to validate the integral matrices. Disable this setting with
+                care!
             auto_index_order: whether or not to automatically convert the matrices to physicists'
                 order.
 

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -469,7 +469,7 @@ class ElectronicIntegrals(LinearMixin):
                 operands. This function must take a sequence of numpy (or sparse) arrays as its
                 first argument. You should use :code:`functools.partial` if you need to provide
                 keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`). Common methods to use
-                here are :meth:`numpy.hstack` and :meth:`numpy.vstack`.
+                here are :func:`numpy.hstack` and :func:`numpy.vstack`.
             operands: a sequence of ``ElectronicIntegrals`` instances on which to operate.
             validate: when set to False, no validation will be performed. Disable this setting with
                 care!
@@ -521,7 +521,7 @@ class ElectronicIntegrals(LinearMixin):
                 sparse) array as its first input followed by a sequence of indices to split on.
                 You should use :code:`functools.partial` if you need to provide keyword arguments
                 (e.g. :code:`partial(np.split, axis=-1)`). Common methods to use here are
-                :meth:`numpy.hsplit` and :meth:`numpy.vsplit`.
+                :func:`numpy.hsplit` and :func:`numpy.vsplit`.
             indices_or_sections: a single index or sequence of indices to split on.
             validate: when set to False, no validation will be performed. Disable this setting with
                 care!

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -462,7 +462,8 @@ class ElectronicIntegrals(LinearMixin):
             function: the stacking function to apply to the internal arrays of the provided
                 operands. This function must take a sequence of numpy (or sparse) arrays as its
                 first argument. You should use :code:`functools.partial` if you need to provide
-                keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`)
+                keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`). Common methods to use
+                here are ``np.hstack`` and ``np.vstack``.
             operands: a sequence of ``ElectronicIntegrals`` instances on which to operate.
             validate: when set to False, no validation will be performed. Disable this setting with
                 care!
@@ -507,7 +508,8 @@ class ElectronicIntegrals(LinearMixin):
             function: the splitting function to use. This function must take a single numpy (or
                 sparse) array as its first input followed by a sequence of indices to split on.
                 You should use :code:`functools.partial` if you need to provide keyword arguments
-                (e.g. :code:`partial(np.split, axis=-1)`)
+                (e.g. :code:`partial(np.split, axis=-1)`). Common methods to use here are
+                ``np.hsplit`` and ``np.vsplit``.
             indices_or_sections: a single index or sequence of indices to split on.
             validate: when set to False, no validation will be performed. Disable this setting with
                 care!

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -516,11 +516,13 @@ class ElectronicIntegrals(LinearMixin):
         """
         alphas = self.alpha.split(function, indices_or_sections, validate=validate)
 
+        betas: list[PolynomialTensor | None]
         if self.beta.is_empty():
             betas = [None] * len(alphas)
         else:
             betas = self.beta.split(function, indices_or_sections, validate=validate)
 
+        beta_alphas: list[PolynomialTensor | None]
         if self.beta_alpha.is_empty():
             beta_alphas = [None] * len(alphas)
         else:

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -559,7 +559,7 @@ class ElectronicIntegrals(LinearMixin):
         if h2_ba is not None:
             beta_alpha = PolynomialTensor({"++--": h2_ba}, validate=validate)
 
-        return cls(alpha, beta, beta_alpha)
+        return cls(alpha, beta, beta_alpha, validate=validate)
 
     def second_q_coeffs(self) -> PolynomialTensor:
         """Constructs the total ``PolynomialTensor`` contained the second-quantized coefficients.

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -458,6 +458,12 @@ class ElectronicIntegrals(LinearMixin):
         The :attr:`beta_alpha` attributes will only be handled if they are non-empty in all supplied
         operands.
 
+        .. note::
+
+            When stacking arrays this will likely lead to array shapes which would fail the shape
+            validation check. This is considered an advanced use case which is why the user is left
+            to disable this check themselves, to ensure they know what they are doing.
+
         Args:
             function: the stacking function to apply to the internal arrays of the provided
                 operands. This function must take a sequence of numpy (or sparse) arrays as its
@@ -503,6 +509,12 @@ class ElectronicIntegrals(LinearMixin):
         This behaves identical to the ``split`` implementation of the ``PolynomialTensor``, applied
         to the :attr:`alpha`, :attr:`beta`, and :attr:`beta_alpha` attributes of the provided
         ``ElectronicIntegrals`` operands.
+
+        .. note::
+
+            When splitting arrays this will likely lead to array shapes which would fail the shape
+            validation check. This is considered an advanced use case which is why the user is left
+            to disable this check themselves, to ensure they know what they are doing.
 
         Args:
             function: the splitting function to use. This function must take a single numpy (or

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from numbers import Number
-from typing import Tuple, cast
+from typing import Sequence, Tuple, cast
 
 import numpy as np
 
@@ -413,7 +413,7 @@ class ElectronicIntegrals(LinearMixin):
             validate: when set to False, no validation will be performed.
 
         Returns:
-            A new ``PolynomialTensor``.
+            A new ``ElectronicIntegrals``.
         """
         alpha = PolynomialTensor.apply(function, *(op.alpha for op in operands), validate=validate)
 
@@ -439,11 +439,32 @@ class ElectronicIntegrals(LinearMixin):
     def stack(
         cls,
         function: Callable[..., np.ndarray | SparseArray | Number],
-        operands: Sequence[PolynomialTensor],
+        operands: Sequence[ElectronicIntegrals],
         *,
         validate: bool = True,
-    ) -> PolynomialTensor:
-        """TODO."""
+    ) -> ElectronicIntegrals:
+        """Exposes the :meth:`qiskit_nature.second_q.operators.PolynomialTensor.stack` method.
+
+        This behaves identical to the ``stack`` implementation of the ``PolynomialTensor``, applied
+        to the :attr:`alpha`, :attr:`beta`, and :attr:`beta_alpha` attributes of the provided
+        ``ElectronicIntegrals`` operands.
+
+        This method is special, because it handles the scenario in which any operand has a non-empty
+        :attr:`beta` attribute, in which case the empty-beta attributes of any other operands will
+        be filled with :attr:`alpha` attributes of those operands.
+        The same applies to the :attr:`beta_alpha` attributes.
+
+        Args:
+            function: the stacking function to apply to the internal arrays of the provided
+                operands. This function must take a sequence of numpy (or sparse) arrays as its
+                first argument. You should use :code:`functools.partial` if you need to provide
+                keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`)
+            operands: a sequence of ``ElectronicIntegrals`` instances on which to operate.
+            validate: when set to False, no validation will be performed.
+
+        Returns:
+            A new ``ElectronicIntegrals``.
+        """
         alpha = PolynomialTensor.stack(function, [op.alpha for op in operands], validate=validate)
 
         beta: PolynomialTensor = None
@@ -470,8 +491,29 @@ class ElectronicIntegrals(LinearMixin):
         indices_or_sections: int | Sequence[int],
         *,
         validate: bool = True,
-    ) -> list[PolynomialTensor]:
-        """TODO."""
+    ) -> list[ElectronicIntegrals]:
+        """Exposes the :meth:`qiskit_nature.second_q.operators.PolynomialTensor.split` method.
+
+        This behaves identical to the ``split`` implementation of the ``PolynomialTensor``, applied
+        to the :attr:`alpha`, :attr:`beta`, and :attr:`beta_alpha` attributes of the provided
+        ``ElectronicIntegrals`` operands.
+
+        This method is special, because it handles the scenario in which any operand has a non-empty
+        :attr:`beta` attribute, in which case the empty-beta attributes of any other operands will
+        be filled with :attr:`alpha` attributes of those operands.
+        The same applies to the :attr:`beta_alpha` attributes.
+
+        Args:
+            function: the splitting function to use. This function must take a single numpy (or
+                sparse) array as its first input followed by a sequence of indices to split on.
+                You should use :code:`functools.partial` if you need to provide keyword arguments
+                (e.g. :code:`partial(np.split, axis=-1)`)
+            indices_or_sections: a single index or sequence of indices to split on.
+            validate: when set to False, no validation will be performed.
+
+        Returns:
+            The new ``ElectronicIntegrals`` instances.
+        """
         alphas = self.alpha.split(function, indices_or_sections, validate=validate)
 
         if self.beta.is_empty():
@@ -516,7 +558,7 @@ class ElectronicIntegrals(LinearMixin):
             validate: when set to False, no validation will be performed.
 
         Returns:
-            A new ``PolynomialTensor``.
+            A new ``ElectronicIntegrals``.
         """
         alpha = PolynomialTensor.einsum(
             einsum_map, *(op.alpha for op in operands), validate=validate

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -403,7 +403,8 @@ class ElectronicIntegrals(LinearMixin):
         This method is special, because it handles the scenario in which any operand has a non-empty
         :attr:`beta` attribute, in which case the empty-beta attributes of any other operands will
         be filled with :attr:`alpha` attributes of those operands.
-        The same applies to the :attr:`beta_alpha` attributes.
+        The :attr:`beta_alpha` attributes will only be handled if they are non-empty in all supplied
+        operands.
 
         Args:
             function: the function to apply to the internal arrays of the provided operands. This
@@ -452,7 +453,8 @@ class ElectronicIntegrals(LinearMixin):
         This method is special, because it handles the scenario in which any operand has a non-empty
         :attr:`beta` attribute, in which case the empty-beta attributes of any other operands will
         be filled with :attr:`alpha` attributes of those operands.
-        The same applies to the :attr:`beta_alpha` attributes.
+        The :attr:`beta_alpha` attributes will only be handled if they are non-empty in all supplied
+        operands.
 
         Args:
             function: the stacking function to apply to the internal arrays of the provided
@@ -497,11 +499,6 @@ class ElectronicIntegrals(LinearMixin):
         This behaves identical to the ``split`` implementation of the ``PolynomialTensor``, applied
         to the :attr:`alpha`, :attr:`beta`, and :attr:`beta_alpha` attributes of the provided
         ``ElectronicIntegrals`` operands.
-
-        This method is special, because it handles the scenario in which any operand has a non-empty
-        :attr:`beta` attribute, in which case the empty-beta attributes of any other operands will
-        be filled with :attr:`alpha` attributes of those operands.
-        The same applies to the :attr:`beta_alpha` attributes.
 
         Args:
             function: the splitting function to use. This function must take a single numpy (or
@@ -549,7 +546,8 @@ class ElectronicIntegrals(LinearMixin):
         This method is special, because it handles the scenario in which any operand has a non-empty
         :attr:`beta` attribute, in which case the empty-beta attributes of any other operands will
         be filled with :attr:`alpha` attributes of those operands.
-        The same applies to the :attr:`beta_alpha` attributes.
+        The :attr:`beta_alpha` attributes will only be handled if they are non-empty in all supplied
+        operands.
 
         Args:
             einsum_map: a dictionary, mapping from :meth:`numpy.einsum` subscripts to a tuple of

--- a/qiskit_nature/second_q/operators/polynomial_tensor.py
+++ b/qiskit_nature/second_q/operators/polynomial_tensor.py
@@ -665,7 +665,8 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
             function: the stacking function to apply to the internal arrays of the provided
                 operands. This function must take a sequence of numpy (or sparse) arrays as its
                 first argument. You should use :code:`functools.partial` if you need to provide
-                keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`)
+                keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`). Common methods to use
+                here are ``np.hstack`` and ``np.vstack``.
             operands: a sequence of ``PolynomialTensor`` instances on which to operate.
             validate: when set to False the ``data`` will not be validated. Disable this setting
                 with care!
@@ -698,12 +699,12 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
             ab = PolynomialTensor({"+-": rand_ab})
 
             # np.hsplit
-            a, b = ab.stack(np.hsplit, [2], validate=False)
+            a, b = ab.split(np.hsplit, [2], validate=False)
             print(a == PolynomialTensor({"+-": np.hsplit(ab, [2])[0], validate=False)}))  # True
             print(b == PolynomialTensor({"+-": np.hsplit(ab, [2])[1], validate=False)}))  # True
 
             # np.vsplit
-            a, b = ab.stack(np.vsplit, [2], validate=False)
+            a, b = ab.split(np.vsplit, [2], validate=False)
             print(a == PolynomialTensor({"+-": np.vsplit(ab, [2])[0], validate=False)}))  # True
             print(b == PolynomialTensor({"+-": np.vsplit(ab, [2])[1], validate=False)}))  # True
 
@@ -711,7 +712,8 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
             function: the splitting function to use. This function must take a single numpy (or
                 sparse) array as its first input followed by a sequence of indices to split on.
                 You should use :code:`functools.partial` if you need to provide keyword arguments
-                (e.g. :code:`partial(np.split, axis=-1)`)
+                (e.g. :code:`partial(np.split, axis=-1)`). Common methods to use here are
+                ``np.hsplit`` and ``np.vsplit``.
             indices_or_sections: a single index or sequence of indices to split on.
             validate: when set to False the ``data`` will not be validated. Disable this setting
                 with care!

--- a/qiskit_nature/second_q/operators/polynomial_tensor.py
+++ b/qiskit_nature/second_q/operators/polynomial_tensor.py
@@ -673,7 +673,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
                 operands. This function must take a sequence of numpy (or sparse) arrays as its
                 first argument. You should use :code:`functools.partial` if you need to provide
                 keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`). Common methods to use
-                here are :meth:`numpy.hstack` and :meth:`numpy.vstack`.
+                here are :func:`numpy.hstack` and :func:`numpy.vstack`.
             operands: a sequence of ``PolynomialTensor`` instances on which to operate.
             validate: when set to False the ``data`` will not be validated. Disable this setting
                 with care!
@@ -727,7 +727,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
                 sparse) array as its first input followed by a sequence of indices to split on.
                 You should use :code:`functools.partial` if you need to provide keyword arguments
                 (e.g. :code:`partial(np.split, axis=-1)`). Common methods to use here are
-                :meth:`numpy.hsplit` and :meth:`numpy.vsplit`.
+                :func:`numpy.hsplit` and :func:`numpy.vsplit`.
             indices_or_sections: a single index or sequence of indices to split on.
             validate: when set to False the ``data`` will not be validated. Disable this setting
                 with care!

--- a/qiskit_nature/second_q/operators/polynomial_tensor.py
+++ b/qiskit_nature/second_q/operators/polynomial_tensor.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from itertools import product
 from numbers import Number
-from typing import Iterator, Type, Union, cast
+from typing import Iterator, Sequence, Type, Union, cast
 
 import numpy as np
 
@@ -185,8 +185,8 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
                 automatically be wrapped into one. Upon retrieval via item access (``__getitem__``)
                 automatically wrapped objects will be unwrapped again depending on the value of
                 :attr:`~qiskit_nature.settings.tensor_unwrapping`.
-            validate: when set to False the ``data`` will not be validated. Disable this setting with
-                care!
+            validate: when set to False the ``data`` will not be validated. Disable this setting
+                with care!
 
         Raises:
             ValueError: when length of operator key does not match dimensions of value matrix.
@@ -614,8 +614,8 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
                 function must take numpy (or sparse) arrays as its positional arguments. The number
                 of arguments must match the number of provided operands.
             operands: a sequence of ``PolynomialTensor`` instances on which to operate.
-            validate: when set to False the `data` will not be validated. Disable this setting with
-                care!
+            validate: when set to False the ``data`` will not be validated. Disable this setting
+                with care!
 
         Returns:
             A new ``PolynomialTensor`` instance with the resulting arrays.
@@ -634,11 +634,49 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
         *,
         validate: bool = True,
     ) -> PolynomialTensor:
-        """TODO."""
+        """Stacks the provided sequence of tensors using the given numpy stacking function.
+
+        The usage of this method is best explained by some examples:
+
+        .. code-block:: python
+
+            import numpy as np
+            from qiskit_nature.second_q.opertors import PolynomialTensor
+            rand_a = np.random.random((2, 2))
+            rand_b = np.random.random((2, 2))
+            a = PolynomialTensor({"+-": rand_a})
+            b = PolynomialTensor({"+": np.random.random(2), "+-": rand_b})
+
+            # np.hstack
+            ab_hstack = PolynomialTensor.stack(np.hstack, [a, b], validate=False)
+            print(ab_hstack == PolynomialTensor({"+-": np.hstack([a, b], validate=False)}))  # True
+
+            # np.vstack
+            ab_vstack = PolynomialTensor.stack(np.vstack, [a, b], validate=False)
+            print(ab_vstack == PolynomialTensor({"+-": np.vstack([a, b], validate=False)}))  # True
+
+        .. note::
+
+            The provided function will only be applied to the internal arrays of the common keys of
+            all provided ``PolynomialTensor`` instances. That means, that no cross-products will be
+            generated.
+
+        Args:
+            function: the stacking function to apply to the internal arrays of the provided
+                operands. This function must take a sequence of numpy (or sparse) arrays as its
+                first argument. You should use :code:`functools.partial` if you need to provide
+                keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`)
+            operands: a sequence of ``PolynomialTensor`` instances on which to operate.
+            validate: when set to False the ``data`` will not be validated. Disable this setting
+                with care!
+
+        Returns:
+            A new ``PolynomialTensor`` instance with the resulting arrays.
+        """
         common_keys = set.intersection(*(set(op) for op in operands))
-        new_data: dict[str, ARRAY_TYPE | Number] = {}
+        new_data: dict[str, Tensor | Number] = {}
         for key in common_keys:
-            new_data[key] = function([*(op[key] for op in operands)])
+            new_data[key] = cast(Tensor, function([*(op[key] for op in operands)]))
         return cls(new_data, validate=validate)
 
     def split(
@@ -648,10 +686,44 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
         *,
         validate: bool = True,
     ) -> list[PolynomialTensor]:
-        """TODO."""
-        new_tensors: list[dict[str, ARRAY_TYPE | Number]] = []
+        """Splits the acted on tensor instance using the given numpy splitting function.
+
+        The usage of this method is best explained by some examples:
+
+        .. code-block:: python
+
+            import numpy as np
+            from qiskit_nature.second_q.opertors import PolynomialTensor
+            rand_ab = np.random.random((4, 4))
+            ab = PolynomialTensor({"+-": rand_ab})
+
+            # np.hsplit
+            a, b = ab.stack(np.hsplit, [2], validate=False)
+            print(a == PolynomialTensor({"+-": np.hsplit(ab, [2])[0], validate=False)}))  # True
+            print(b == PolynomialTensor({"+-": np.hsplit(ab, [2])[1], validate=False)}))  # True
+
+            # np.vsplit
+            a, b = ab.stack(np.vsplit, [2], validate=False)
+            print(a == PolynomialTensor({"+-": np.vsplit(ab, [2])[0], validate=False)}))  # True
+            print(b == PolynomialTensor({"+-": np.vsplit(ab, [2])[1], validate=False)}))  # True
+
+        Args:
+            function: the splitting function to use. This function must take a single numpy (or
+                sparse) array as its first input followed by a sequence of indices to split on.
+                You should use :code:`functools.partial` if you need to provide keyword arguments
+                (e.g. :code:`partial(np.split, axis=-1)`)
+            indices_or_sections: a single index or sequence of indices to split on.
+            validate: when set to False the ``data`` will not be validated. Disable this setting
+                with care!
+
+        Returns:
+            New ``PolynomialTensor`` instances containing the split arrays.
+        """
+        new_tensors: list[dict[str, Tensor | Number]] = []
         for key, arr in self._data.items():
-            for idx, new_arr in enumerate(function(arr, indices_or_sections)):
+            for idx, new_arr in enumerate(
+                function(arr, indices_or_sections)  # type: ignore[arg-type]
+            ):
                 if idx < len(new_tensors):
                     new_tensors[idx][key] = new_arr
                 else:
@@ -725,8 +797,8 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
                 provided ``PolynomialTensor`` operands. The last string in this tuple indicates the
                 key under which to store the result in the returned ``PolynomialTensor``.
             operands: a sequence of ``PolynomialTensor`` instances on which to operate.
-            validate: when set to False the `data` will not be validated. Disable this setting with
-                care!
+            validate: when set to False the ``data`` will not be validated. Disable this setting
+                with care!
 
         Returns:
             A new ``PolynomialTensor``.

--- a/qiskit_nature/second_q/operators/polynomial_tensor.py
+++ b/qiskit_nature/second_q/operators/polynomial_tensor.py
@@ -661,6 +661,13 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
             all provided ``PolynomialTensor`` instances. That means, that no cross-products will be
             generated.
 
+        .. note::
+
+            When stacking arrays this will likely lead to array shapes which would fail the shape
+            validation check (as you can see from the examples above where we explicitly disable
+            them). This is considered an advanced use case which is why the user is left to disable
+            this check themselves, to ensure they know what they are doing.
+
         Args:
             function: the stacking function to apply to the internal arrays of the provided
                 operands. This function must take a sequence of numpy (or sparse) arrays as its
@@ -707,6 +714,13 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
             a, b = ab.split(np.vsplit, [2], validate=False)
             print(a == PolynomialTensor({"+-": np.vsplit(ab, [2])[0], validate=False)}))  # True
             print(b == PolynomialTensor({"+-": np.vsplit(ab, [2])[1], validate=False)}))  # True
+
+        .. note::
+
+            When splitting arrays this will likely lead to array shapes which would fail the shape
+            validation check (as you can see from the examples above where we explicitly disable
+            them). This is considered an advanced use case which is why the user is left to disable
+            this check themselves, to ensure they know what they are doing.
 
         Args:
             function: the splitting function to use. This function must take a single numpy (or

--- a/qiskit_nature/second_q/operators/polynomial_tensor.py
+++ b/qiskit_nature/second_q/operators/polynomial_tensor.py
@@ -666,7 +666,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
                 operands. This function must take a sequence of numpy (or sparse) arrays as its
                 first argument. You should use :code:`functools.partial` if you need to provide
                 keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`). Common methods to use
-                here are ``np.hstack`` and ``np.vstack``.
+                here are :meth:`np.hstack` and :meth:`np.vstack`.
             operands: a sequence of ``PolynomialTensor`` instances on which to operate.
             validate: when set to False the ``data`` will not be validated. Disable this setting
                 with care!
@@ -713,7 +713,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
                 sparse) array as its first input followed by a sequence of indices to split on.
                 You should use :code:`functools.partial` if you need to provide keyword arguments
                 (e.g. :code:`partial(np.split, axis=-1)`). Common methods to use here are
-                ``np.hsplit`` and ``np.vsplit``.
+                :meth:`np.hsplit` and :meth:`np.vsplit`.
             indices_or_sections: a single index or sequence of indices to split on.
             validate: when set to False the ``data`` will not be validated. Disable this setting
                 with care!

--- a/qiskit_nature/second_q/operators/polynomial_tensor.py
+++ b/qiskit_nature/second_q/operators/polynomial_tensor.py
@@ -673,7 +673,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
                 operands. This function must take a sequence of numpy (or sparse) arrays as its
                 first argument. You should use :code:`functools.partial` if you need to provide
                 keyword arguments (e.g. :code:`partial(np.stack, axis=-1)`). Common methods to use
-                here are :meth:`np.hstack` and :meth:`np.vstack`.
+                here are :meth:`numpy.hstack` and :meth:`numpy.vstack`.
             operands: a sequence of ``PolynomialTensor`` instances on which to operate.
             validate: when set to False the ``data`` will not be validated. Disable this setting
                 with care!
@@ -727,7 +727,7 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
                 sparse) array as its first input followed by a sequence of indices to split on.
                 You should use :code:`functools.partial` if you need to provide keyword arguments
                 (e.g. :code:`partial(np.split, axis=-1)`). Common methods to use here are
-                :meth:`np.hsplit` and :meth:`np.vsplit`.
+                :meth:`numpy.hsplit` and :meth:`numpy.vsplit`.
             indices_or_sections: a single index or sequence of indices to split on.
             validate: when set to False the ``data`` will not be validated. Disable this setting
                 with care!

--- a/releasenotes/notes/feat-tensor-splitting-and-stacking-610c2de4f3353a1d.yaml
+++ b/releasenotes/notes/feat-tensor-splitting-and-stacking-610c2de4f3353a1d.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Adds the following new utility methods for splitting and stacking mulit-tensors:
+    Adds the following new utility methods for splitting and stacking multi-tensors:
 
     - :meth:`.PolynomialTensor.split`
     - :meth:`.PolynomialTensor.stack`

--- a/releasenotes/notes/feat-tensor-splitting-and-stacking-610c2de4f3353a1d.yaml
+++ b/releasenotes/notes/feat-tensor-splitting-and-stacking-610c2de4f3353a1d.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Adds the following new utility methods for splitting and stacking mulit-tensors:
+
+    - :meth:`.PolynomialTensor.split`
+    - :meth:`.PolynomialTensor.stack`
+    - :meth:`.ElectronicIntegrals.split`
+    - :meth:`.ElectronicIntegrals.stack`

--- a/test/second_q/operators/test_electronic_integrals.py
+++ b/test/second_q/operators/test_electronic_integrals.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/operators/test_electronic_integrals.py
+++ b/test/second_q/operators/test_electronic_integrals.py
@@ -517,6 +517,74 @@ class TestElectronicIntegrals(QiskitNatureTestCase):
             )
             self.assertTrue(tensor.equiv(expected))
 
+    def test_stack(self):
+        """Test ElectronicIntegrals.stack"""
+        one_body_1 = np.random.random((2, 2))
+        one_body_2 = np.random.random((2, 2))
+        one_body_3 = np.random.random((2, 2))
+        one_body_4 = np.random.random((2, 2))
+
+        with self.subTest("alpha only"):
+            ints1 = ElectronicIntegrals(PolynomialTensor({"": 1, "+-": one_body_1}))
+            ints2 = ElectronicIntegrals(PolynomialTensor({"+-": one_body_2}))
+            result = ElectronicIntegrals.stack(np.hstack, [ints1, ints2], validate=False)
+            expected = ElectronicIntegrals(
+                PolynomialTensor({"+-": np.hstack([one_body_1, one_body_2])}, validate=False)
+            )
+            self.assertTrue(result.equiv(expected))
+
+        with self.subTest("alpha and partial beta ints"):
+            ints1 = ElectronicIntegrals(
+                PolynomialTensor({"": 1, "+-": one_body_1}),
+                PolynomialTensor({"+-": one_body_3}),
+            )
+            ints2 = ElectronicIntegrals(PolynomialTensor({"+-": one_body_2}))
+            result = ElectronicIntegrals.stack(np.hstack, [ints1, ints2], validate=False)
+            expected = ElectronicIntegrals(
+                PolynomialTensor({"+-": np.hstack([one_body_1, one_body_2])}, validate=False),
+                PolynomialTensor({"+-": np.hstack([one_body_3, one_body_2])}, validate=False),
+            )
+            self.assertTrue(result.equiv(expected))
+
+    def test_split(self):
+        """Test ElectronicIntegrals.split"""
+        one_body_1 = np.random.random((4, 4))
+        exp1a, exp1b = np.hsplit(one_body_1, [2])
+        one_body_2 = np.random.random((4, 4))
+        exp2a, exp2b = np.hsplit(one_body_2, [2])
+
+        with self.subTest("alpha only"):
+            ints1 = ElectronicIntegrals(PolynomialTensor({"+-": one_body_1}))
+            res1, res2 = ints1.split(np.hsplit, [2], validate=False)
+            self.assertTrue(
+                res1.equiv(ElectronicIntegrals(PolynomialTensor({"+-": exp1a}, validate=False)))
+            )
+            self.assertTrue(
+                res2.equiv(ElectronicIntegrals(PolynomialTensor({"+-": exp1b}, validate=False)))
+            )
+
+        with self.subTest("alpha and beta"):
+            ints1 = ElectronicIntegrals(
+                PolynomialTensor({"+-": one_body_1}), PolynomialTensor({"+-": one_body_2})
+            )
+            res1, res2 = ints1.split(np.hsplit, [2], validate=False)
+            self.assertTrue(
+                res1.equiv(
+                    ElectronicIntegrals(
+                        PolynomialTensor({"+-": exp1a}, validate=False),
+                        PolynomialTensor({"+-": exp2a}, validate=False),
+                    )
+                )
+            )
+            self.assertTrue(
+                res2.equiv(
+                    ElectronicIntegrals(
+                        PolynomialTensor({"+-": exp1b}, validate=False),
+                        PolynomialTensor({"+-": exp2b}, validate=False),
+                    )
+                )
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/second_q/operators/test_electronic_integrals.py
+++ b/test/second_q/operators/test_electronic_integrals.py
@@ -522,7 +522,6 @@ class TestElectronicIntegrals(QiskitNatureTestCase):
         one_body_1 = np.random.random((2, 2))
         one_body_2 = np.random.random((2, 2))
         one_body_3 = np.random.random((2, 2))
-        one_body_4 = np.random.random((2, 2))
 
         with self.subTest("alpha only"):
             ints1 = ElectronicIntegrals(PolynomialTensor({"": 1, "+-": one_body_1}))

--- a/test/second_q/operators/test_polynomial_tensor.py
+++ b/test/second_q/operators/test_polynomial_tensor.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import unittest
+from functools import partial
 from test import QiskitNatureTestCase
 
 import numpy as np
@@ -724,6 +725,85 @@ class TestPolynomialTensor(QiskitNatureTestCase):
         with self.subTest("np.kron"):
             ab_kron = PolynomialTensor.apply(np.kron, a, b)
             self.assertEqual(ab_kron, PolynomialTensor({"+-": np.kron(rand_a, rand_b)}))
+
+    def test_stack(self):
+        """Test PolynomialTensor.stack"""
+        rand_a = np.random.random((2, 2))
+        rand_b = np.random.random((2, 2))
+        a = PolynomialTensor({"+-": rand_a})
+        b = PolynomialTensor({"+": np.random.random(2), "+-": rand_b})
+
+        with self.subTest("np.hstack"):
+            ab_exp = PolynomialTensor({"+-": np.hstack([rand_a, rand_b])}, validate=False)
+            ab_real = PolynomialTensor.stack(np.hstack, [a, b], validate=False)
+            self.assertEqual(ab_real, ab_exp)
+
+        with self.subTest("np.vstack"):
+            ab_exp = PolynomialTensor({"+-": np.vstack([rand_a, rand_b])}, validate=False)
+            ab_real = PolynomialTensor.stack(np.vstack, [a, b], validate=False)
+            self.assertEqual(ab_real, ab_exp)
+
+        with self.subTest("np.dstack"):
+            ab_exp = PolynomialTensor({"+-": np.dstack([rand_a, rand_b])}, validate=False)
+            ab_real = PolynomialTensor.stack(np.dstack, [a, b], validate=False)
+            self.assertEqual(ab_real, ab_exp)
+
+        with self.subTest("np.stack"):
+            ab_exp = PolynomialTensor({"+-": np.stack([rand_a, rand_b])}, validate=False)
+            ab_real = PolynomialTensor.stack(np.stack, [a, b], validate=False)
+            self.assertEqual(ab_real, ab_exp)
+
+        with self.subTest("np.stack axis=-1"):
+            ab_exp = PolynomialTensor({"+-": np.stack([rand_a, rand_b], axis=-1)}, validate=False)
+            ab_real = PolynomialTensor.stack(partial(np.stack, axis=-1), [a, b], validate=False)
+            self.assertEqual(ab_real, ab_exp)
+
+    def test_split(self):
+        """Test PolynomialTensor.split"""
+        rand_ab = np.random.random((4, 4))
+        ab = PolynomialTensor({"+-": rand_ab})
+
+        with self.subTest("np.hsplit"):
+            a_exp, b_exp = np.hsplit(rand_ab, 2)
+            a_real, b_real = ab.split(np.hsplit, 2, validate=False)
+            self.assertEqual(a_real, PolynomialTensor({"+-": a_exp}, validate=False))
+            self.assertEqual(b_real, PolynomialTensor({"+-": b_exp}, validate=False))
+
+        with self.subTest("np.vsplit"):
+            a_exp, b_exp = np.vsplit(rand_ab, 2)
+            a_real, b_real = ab.split(np.vsplit, 2, validate=False)
+            self.assertEqual(a_real, PolynomialTensor({"+-": a_exp}, validate=False))
+            self.assertEqual(b_real, PolynomialTensor({"+-": b_exp}, validate=False))
+
+        with self.subTest("np.split"):
+            a_exp, b_exp = np.split(rand_ab, 2)
+            a_real, b_real = ab.split(np.split, 2, validate=False)
+            self.assertEqual(a_real, PolynomialTensor({"+-": a_exp}, validate=False))
+            self.assertEqual(b_real, PolynomialTensor({"+-": b_exp}, validate=False))
+
+        with self.subTest("np.split axis=-1"):
+            a_exp, b_exp = np.split(rand_ab, 2, axis=-1)
+            a_real, b_real = ab.split(partial(np.split, axis=-1), 2, validate=False)
+            self.assertEqual(a_real, PolynomialTensor({"+-": a_exp}, validate=False))
+            self.assertEqual(b_real, PolynomialTensor({"+-": b_exp}, validate=False))
+
+        with self.subTest("np.dsplit"):
+            rand_ab = np.random.random((2, 2, 2))
+            ab = PolynomialTensor({"+++": rand_ab})
+            a_exp, b_exp = np.dsplit(rand_ab, [1])
+            a_real, b_real = ab.split(np.dsplit, [1], validate=False)
+            self.assertEqual(a_real, PolynomialTensor({"+++": a_exp}, validate=False))
+            self.assertEqual(b_real, PolynomialTensor({"+++": b_exp}, validate=False))
+
+        with self.subTest("multi np.split"):
+            rand_abcd = np.random.random((8, 8))
+            abcd = PolynomialTensor({"+-": rand_abcd})
+            a_exp, b_exp, c_exp, d_exp = np.split(rand_abcd, [2, 4, 6])
+            a_real, b_real, c_real, d_real = abcd.split(np.split, [2, 4, 6], validate=False)
+            self.assertEqual(a_real, PolynomialTensor({"+-": a_exp}, validate=False))
+            self.assertEqual(b_real, PolynomialTensor({"+-": b_exp}, validate=False))
+            self.assertEqual(c_real, PolynomialTensor({"+-": c_exp}, validate=False))
+            self.assertEqual(d_real, PolynomialTensor({"+-": d_exp}, validate=False))
 
     def test_einsum(self):
         """Test PolynomialTensor.einsum"""

--- a/test/second_q/operators/test_polynomial_tensor.py
+++ b/test/second_q/operators/test_polynomial_tensor.py
@@ -761,37 +761,37 @@ class TestPolynomialTensor(QiskitNatureTestCase):
     def test_split(self):
         """Test PolynomialTensor.split"""
         rand_ab = np.random.random((4, 4))
-        ab = PolynomialTensor({"+-": rand_ab})
+        poly_ab = PolynomialTensor({"+-": rand_ab})
 
         with self.subTest("np.hsplit"):
             a_exp, b_exp = np.hsplit(rand_ab, 2)
-            a_real, b_real = ab.split(np.hsplit, 2, validate=False)
+            a_real, b_real = poly_ab.split(np.hsplit, 2, validate=False)
             self.assertEqual(a_real, PolynomialTensor({"+-": a_exp}, validate=False))
             self.assertEqual(b_real, PolynomialTensor({"+-": b_exp}, validate=False))
 
         with self.subTest("np.vsplit"):
             a_exp, b_exp = np.vsplit(rand_ab, 2)
-            a_real, b_real = ab.split(np.vsplit, 2, validate=False)
+            a_real, b_real = poly_ab.split(np.vsplit, 2, validate=False)
             self.assertEqual(a_real, PolynomialTensor({"+-": a_exp}, validate=False))
             self.assertEqual(b_real, PolynomialTensor({"+-": b_exp}, validate=False))
 
         with self.subTest("np.split"):
             a_exp, b_exp = np.split(rand_ab, 2)
-            a_real, b_real = ab.split(np.split, 2, validate=False)
+            a_real, b_real = poly_ab.split(np.split, 2, validate=False)
             self.assertEqual(a_real, PolynomialTensor({"+-": a_exp}, validate=False))
             self.assertEqual(b_real, PolynomialTensor({"+-": b_exp}, validate=False))
 
         with self.subTest("np.split axis=-1"):
             a_exp, b_exp = np.split(rand_ab, 2, axis=-1)
-            a_real, b_real = ab.split(partial(np.split, axis=-1), 2, validate=False)
+            a_real, b_real = poly_ab.split(partial(np.split, axis=-1), 2, validate=False)
             self.assertEqual(a_real, PolynomialTensor({"+-": a_exp}, validate=False))
             self.assertEqual(b_real, PolynomialTensor({"+-": b_exp}, validate=False))
 
         with self.subTest("np.dsplit"):
             rand_ab = np.random.random((2, 2, 2))
-            ab = PolynomialTensor({"+++": rand_ab})
+            poly_ab = PolynomialTensor({"+++": rand_ab})
             a_exp, b_exp = np.dsplit(rand_ab, [1])
-            a_real, b_real = ab.split(np.dsplit, [1], validate=False)
+            a_real, b_real = poly_ab.split(np.dsplit, [1], validate=False)
             self.assertEqual(a_real, PolynomialTensor({"+++": a_exp}, validate=False))
             self.assertEqual(b_real, PolynomialTensor({"+++": b_exp}, validate=False))
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In a recent project I had to implement a lot of array stacking and splitting.
This use case cannot be handle by our `.apply` utilities of `PolynomialTensor` and `ElectronicIntegrals` because:
- in the stacking case the numpy routines expect the arrays to be stacked provided as a list rather than separate positional arguments
- in the splitting case we return multiple tensors instead of one

The latter case would have been possible to implement in a "multi-apply" setting (which I plan to add in the future, too) but splitting arrays is fairly common so I think it deserves its own utility.

### Details and comments


