### PR TITLE
Add the `multi` argument to `PolynomialTensor.apply`

### DIFF
--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from numbers import Number
-from typing import Sequence, Tuple, cast
+from typing import Optional, Sequence, Tuple, cast
 
 import numpy as np
 
@@ -393,8 +393,9 @@ class ElectronicIntegrals(LinearMixin):
         cls,
         function: Callable[..., np.ndarray | SparseArray | complex],
         *operands: ElectronicIntegrals,
+        multi: bool = False,
         validate: bool = True,
-    ) -> ElectronicIntegrals:
+    ) -> ElectronicIntegrals | list[ElectronicIntegrals]:
         """Exposes the :meth:`qiskit_nature.second_q.operators.PolynomialTensor.apply` method.
 
         This behaves identical to the ``apply`` implementation of the ``PolynomialTensor``, applied
@@ -418,25 +419,41 @@ class ElectronicIntegrals(LinearMixin):
         Returns:
             A new ``ElectronicIntegrals``.
         """
-        alpha = PolynomialTensor.apply(function, *(op.alpha for op in operands), validate=validate)
+        alphas = PolynomialTensor.apply(
+            function, *(op.alpha for op in operands), multi=multi, validate=validate
+        )
 
-        beta: PolynomialTensor = None
+        betas: PolynomialTensor | list[PolynomialTensor] | None = None
         if any(not op.beta.is_empty() for op in operands):
             # If any beta-entry is non-empty, we have to perform this computation.
             # Empty tensors will be populated with their alpha-terms automatically.
-            beta = PolynomialTensor.apply(
+            betas = PolynomialTensor.apply(
                 function,
                 *(op.alpha if op.beta.is_empty() else op.beta for op in operands),
+                multi=multi,
                 validate=validate,
             )
 
-        beta_alpha: PolynomialTensor = None
+        beta_alphas: PolynomialTensor | list[PolynomialTensor] | None = None
         if all(not op.beta_alpha.is_empty() for op in operands):
             # We can only perform this operation, when all beta_alpha tensors are non-empty.
-            beta_alpha = PolynomialTensor.apply(
-                function, *(op.beta_alpha for op in operands), validate=validate
+            beta_alphas = PolynomialTensor.apply(
+                function, *(op.beta_alpha for op in operands), multi=multi, validate=validate
             )
-        return cls(alpha, beta, beta_alpha, validate=validate)
+
+        if multi:
+            if betas is None:
+                betas = [None] * len(alphas)
+            if beta_alphas is None:
+                beta_alphas = [None] * len(alphas)
+            return [
+                cls(a, b, ba, validate=validate) for a, b, ba in zip(alphas, betas, beta_alphas)
+            ]
+
+        alphas = cast(PolynomialTensor, alphas)
+        betas = cast(Optional[PolynomialTensor], betas)
+        beta_alphas = cast(Optional[PolynomialTensor], beta_alphas)
+        return cls(alphas, betas, beta_alphas, validate=validate)
 
     @classmethod
     def stack(

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -743,7 +743,7 @@ class ElectronicIntegrals(LinearMixin):
             kron_two_body[ab_index] = 0.5
 
             tensor_blocked_spin_orbitals = PolynomialTensor.apply(np.kron, kron_tensor, self.alpha)
-            return tensor_blocked_spin_orbitals
+            return cast(PolynomialTensor, tensor_blocked_spin_orbitals)
 
         tensor_blocked_spin_orbitals = PolynomialTensor({})
         # pure alpha spin
@@ -785,7 +785,7 @@ class ElectronicIntegrals(LinearMixin):
             )
             kron_two_body[ab_index] = 0
 
-        return tensor_blocked_spin_orbitals
+        return cast(PolynomialTensor, tensor_blocked_spin_orbitals)
 
     def trace_spin(self) -> PolynomialTensor:
         """Returns a :class:`~.PolynomialTensor` where the spin components have been traced out.

--- a/qiskit_nature/second_q/operators/electronic_integrals.py
+++ b/qiskit_nature/second_q/operators/electronic_integrals.py
@@ -413,6 +413,9 @@ class ElectronicIntegrals(LinearMixin):
                 function must take numpy (or sparse) arrays as its positional arguments. The number
                 of arguments must match the number of provided operands.
             operands: a sequence of ``ElectronicIntegrals`` instances on which to operate.
+            multi: when set to True this indicates that the provided numpy function will return
+                multiple new numpy arrays which will each be wrapped into an ``ElectronicIntegrals``
+                instance separately.
             validate: when set to False, no validation will be performed. Disable this setting with
                 care!
 

--- a/qiskit_nature/second_q/operators/polynomial_tensor.py
+++ b/qiskit_nature/second_q/operators/polynomial_tensor.py
@@ -604,6 +604,12 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
             # "+" key. That is because the function only gets applied to the keys which are common
             # to all tensors passed to it.
 
+            # computing eigenvectors
+            hermi_a = np.array([[1, -2j], [2j, 5]])
+            a = PolynomialTensor({"+-": hermi_a})
+            _, eigvecs = PolynomialTensor.apply(np.linalg.eigh, a, multi=True, validate=False)
+            print(eigvecs == PolynomialTensor({"+-": np.eigh(hermi_a)[1]}))  # True
+
         .. note::
 
             The provided function will only be applied to the internal arrays of the common keys of
@@ -615,6 +621,9 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
                 function must take numpy (or sparse) arrays as its positional arguments. The number
                 of arguments must match the number of provided operands.
             operands: a sequence of ``PolynomialTensor`` instances on which to operate.
+            multi: when set to True this indicates that the provided numpy function will return
+                multiple new numpy arrays which will each be wrapped into a ``PolynomialTensor``
+                instance separately.
             validate: when set to False the ``data`` will not be validated. Disable this setting
                 with care!
 

--- a/qiskit_nature/second_q/operators/polynomial_tensor.py
+++ b/qiskit_nature/second_q/operators/polynomial_tensor.py
@@ -607,8 +607,8 @@ class PolynomialTensor(LinearMixin, GroupMixin, TolerancesMixin, Mapping):
             # computing eigenvectors
             hermi_a = np.array([[1, -2j], [2j, 5]])
             a = PolynomialTensor({"+-": hermi_a})
-            _, eigvecs = PolynomialTensor.apply(np.linalg.eigh, a, multi=True, validate=False)
-            print(eigvecs == PolynomialTensor({"+-": np.eigh(hermi_a)[1]}))  # True
+            _, eigenvectors = PolynomialTensor.apply(np.linalg.eigh, a, multi=True, validate=False)
+            print(eigenvectors == PolynomialTensor({"+-": np.eigh(hermi_a)[1]}))  # True
 
         .. note::
 

--- a/qiskit_nature/second_q/transformers/basis_transformer.py
+++ b/qiskit_nature/second_q/transformers/basis_transformer.py
@@ -96,7 +96,9 @@ class BasisTransformer(BaseTransformer):
         return BasisTransformer(
             self.final_basis,
             self.initial_basis,
-            self.coefficients.__class__.apply(np.transpose, self.coefficients, validate=False),
+            self.coefficients.__class__.apply(  # type: ignore[arg-type]
+                np.transpose, self.coefficients, validate=False
+            ),
         )
 
     def transform(self, problem: BaseProblem) -> BaseProblem:

--- a/releasenotes/notes/feat-polytensor-apply-multi-a3deea9586e6451a.yaml
+++ b/releasenotes/notes/feat-polytensor-apply-multi-a3deea9586e6451a.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    Adds a new ``multi`` argument to the :meth:`PolynomialTensor.apply` method which
+    Adds a new ``multi`` argument to the :meth:`.PolynomialTensor.apply` method which
     allows handling of numpy routines which return more than one array.
-    The same argument also gets exposed by :meth:`ElectronicIntegrals.apply`.
+    The same argument also gets exposed by :meth:`.ElectronicIntegrals.apply`.

--- a/releasenotes/notes/feat-polytensor-apply-multi-a3deea9586e6451a.yaml
+++ b/releasenotes/notes/feat-polytensor-apply-multi-a3deea9586e6451a.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds a new ``multi`` argument to the :meth:`PolynomialTensor.apply` method which
+    allows handling of numpy routines which return more than one array.
+    The same argument also gets exposed by :meth:`ElectronicIntegrals.apply`.

--- a/test/second_q/operators/test_polynomial_tensor.py
+++ b/test/second_q/operators/test_polynomial_tensor.py
@@ -726,6 +726,22 @@ class TestPolynomialTensor(QiskitNatureTestCase):
             ab_kron = PolynomialTensor.apply(np.kron, a, b)
             self.assertEqual(ab_kron, PolynomialTensor({"+-": np.kron(rand_a, rand_b)}))
 
+        with self.subTest("np.linalg.eigh"):
+            hermi_a = np.array([[1, -2j], [2j, 5]])
+            a = PolynomialTensor({"+-": hermi_a})
+            _, eigvecs = PolynomialTensor.apply(np.linalg.eigh, a, multi=True, validate=False)
+            self.assertEqual(eigvecs, PolynomialTensor({"+-": np.linalg.eigh(hermi_a)[1]}))
+
+        with self.subTest("np.linalg.svd"):
+            hermi_a = np.array([[1, -2j], [2j, 5]])
+            a = PolynomialTensor({"+-": hermi_a})
+            _, _, v_t = PolynomialTensor.apply(
+                partial(np.linalg.svd, full_matrices=True), a, multi=True, validate=False
+            )
+            self.assertEqual(
+                v_t, PolynomialTensor({"+-": np.linalg.svd(hermi_a, full_matrices=True)[2]})
+            )
+
     def test_stack(self):
         """Test PolynomialTensor.stack"""
         rand_a = np.random.random((2, 2))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This adds the `multi` argument to the `PolynomialTensor.apply` method as alluded to in #1213.
This allows handling of numpy methods which return multiple numpy arrays and ensures that they are all wrapped by `PolynomialTensor` instances.

### Details and comments

~:warning: To avoid merge conflicts this branch is currently based on #1213. I will rebase it once that PR has been merged.~
