### PR TITLE
fix: Fock computation for mixed spin density in pure spin Hamiltonians

### DIFF
--- a/qiskit_nature/second_q/hamiltonians/electronic_energy.py
+++ b/qiskit_nature/second_q/hamiltonians/electronic_energy.py
@@ -238,19 +238,19 @@ class ElectronicEnergy(Hamiltonian):
             {einsum: ("++--", "+-", "+-")}, self.electronic_integrals, density
         )
 
-        if self.electronic_integrals.beta_alpha.is_empty():
+        if self.electronic_integrals.beta_alpha.is_empty() and density.beta.is_empty():
             coulomb *= 2.0  # type: ignore
         else:
+            if self.electronic_integrals.beta_alpha.is_empty():
+                beta_alpha = self.electronic_integrals.two_body.alpha
+            else:
+                beta_alpha = self.electronic_integrals.beta_alpha
             coulomb.alpha += PolynomialTensor.einsum(
-                {einsum: ("++--", "+-", "+-")},
-                self.electronic_integrals.beta_alpha,
-                density.beta,
+                {einsum: ("++--", "+-", "+-")}, beta_alpha, density.beta
             )
             einsum = einsum[2:4] + einsum[:2] + einsum[4:]
             coulomb.beta += PolynomialTensor.einsum(
-                {einsum: ("++--", "+-", "+-")},
-                self.electronic_integrals.beta_alpha,
-                density.alpha,
+                {einsum: ("++--", "+-", "+-")}, beta_alpha, density.alpha
             )
 
         return coulomb

--- a/releasenotes/notes/fix-fock-5bfbf630809a0570.yaml
+++ b/releasenotes/notes/fix-fock-5bfbf630809a0570.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes the computation of :meth:`.ElectronicEnergy.coulomb` (and by extension
+    :meth:`.ElectronicEnergy.fock`) when applied to a purely alpha-spin Hamiltonian
+    but providing a mixed spin density.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I found a small problem when computing the Fock operator of a pure alpha spin hamiltonian with a mixed spin density.
This can occur for example when using an "AO"-basis hamiltonian.

### Details and comments

