### PR TITLE
Fix spelling of `Schrödinger` in tutorial

### DIFF
--- a/docs/tutorials/01_electronic_structure.ipynb
+++ b/docs/tutorials/01_electronic_structure.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "Because the nuclei are much heavier than the electrons they do not move on the same time scale and therefore, the behavior of nuclei and electrons can be decoupled. This is the Born-Oppenheimer approximation.\n",
     "\n",
-    "Therefore, one can first tackle the electronic problem with the nuclear coordinates entering only as parameters. The energy levels of the electrons in the molecule can then be found by solving the non-relativistic time independent Schroedinger equation,\n",
+    "Therefore, one can first tackle the electronic problem with the nuclear coordinates entering only as parameters. The energy levels of the electrons in the molecule can then be found by solving the non-relativistic time independent Schrödinger equation,\n",
     "\n",
     "$$\n",
     "\\mathcal{H}_{\\text{el}} |\\Psi_{n}\\rangle = E_{n} |\\Psi_{n}\\rangle\n",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
In the tutorial https://qiskit.org/ecosystem/nature/tutorials/01_electronic_structure.html Schroedinger was wrongly written
The correction of "schroedinger" to "Schrödinger" is important for several reasons. First and foremost, it is about giving proper recognition and respect to the scientist by using the correct spelling of his name. 
Furthermore, the correction highlights the significance of Erwin Schrödinger's work in quantum mechanics. His formulation of wave mechanics, which is described by the Schrödinger equation, provided a mathematical framework to describe the behavior of quantum systems. The Schrödinger equation is a fundamental equation in quantum mechanics that describes the time evolution of a quantum state.

University of Oxford https://www-thphys.physics.ox.ac.uk/people/SteveSimon/errors.html
Using an Umlaut over O is conventional and more appropriate 


### Details and comments
In summary, the correction from "schroedinger" to "Schrödinger" is justified based on proper naming conventions, respect for the individual, accuracy in scientific communication, recognition of historical and scientific significance