### PR TITLE
remove deploy documentation to /documentation

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -27,6 +27,3 @@ pwd
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to qiskit.org/ecosystem"
 rclone sync --progress --exclude locale/** ./docs/_build/html IBMCOS:qiskit-org-web-resources/ecosystem/nature
-
-# Push to qiskit.org/documentation
-rclone sync --progress --exclude locale/** ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/nature


### PR DESCRIPTION
Follow up on https://github.com/qiskit-community/qiskit-nature/pull/1103

The documentation is correctly deployed in https://qiskit.org/ecosystem/nature/ and the https://qiskit.org/documentation/nature redirect is working. So, no need to upload to /documentation anymore.