### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/actions/install-psi4/action.yml
+++ b/.github/actions/install-psi4/action.yml
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -29,14 +29,6 @@ runs:
           release=1.6
           echo "installs psi4 release $release"
           conda install -y psi4=$release python=${{ inputs.python-version }} -c psi4 -c conda-forge
-        elif [[ "${{ inputs.os }}" == "ubuntu-latest" && "${{ inputs.python-version }}" == "3.7" ]]; then
-          release=2.6.0
-          echo "installs libint2 release $release"
-          conda install -y libint2=$release -c psi4
-          release=1.5
-          echo "installs psi4 release $release"
-          conda install -y psi4=$release python=${{ inputs.python-version }} -c psi4
-          pip install -U numpy
         elif [[ "${{ inputs.os }}" == "macos-latest" ]]; then
           release=1.6
           echo 'installs psi4 release $release'

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,6 +13,9 @@
 name: 'Run Unit Tests'
 description: 'Run Unit Tests'
 inputs:
+  os:
+    description: 'OS'
+    required: true
   event-name:
     description: 'Actions event'
     required: true
@@ -35,7 +38,7 @@ runs:
         if [ "${{ inputs.event-name }}" == "schedule" ] || [ "${{ inputs.run-slow }}" == "true" ]; then
           export QISKIT_TESTS="run_slow"
         fi
-        if [ "${{ inputs.python-version }}" == "3.7" ]; then
+        if [ "${{ inputs.os }}" == "ubuntu-latest" ] && [ "${{ inputs.python-version }}" == "3.8" ]; then
           export PYTHON="coverage3 run --source qiskit_nature --omit */gauopen/* --parallel-mode"
         fi
         stestr --test-path test run 2> >(tee /dev/stderr out.txt > /dev/null)

--- a/.github/workflows/deploy-code.yml
+++ b/.github/workflows/deploy-code.yml
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,7 +147,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11]
         include:
           - os: macos-latest
             python-version: 3.9
@@ -205,7 +205,7 @@ jobs:
         run: |
           echo "::add-matcher::./.github/problem_matchers/pylint.json"
           echo "::add-matcher::./.github/problem_matchers/mypy.json"
-        if: ${{ matrix.python-version == 3.7 }}
+        if: ${{ matrix.python-version == 3.8 }}
       - name: Run lint
         run: |
           source "$CONDA/etc/profile.d/conda.sh"
@@ -217,14 +217,7 @@ jobs:
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate psi4env
           make mypy
-        if: ${{ !cancelled() && matrix.python-version != 3.7 }}
-        shell: bash
-      - name: Run mypy on Python 3.7
-        run: |
-          source "$CONDA/etc/profile.d/conda.sh"
-          conda activate psi4env
-          python -m mypy --no-warn-unused-ignores qiskit_nature test tools
-        if: ${{ !cancelled() && matrix.python-version == 3.7 }}
+        if: ${{ !cancelled() }}
         shell: bash
       - name: Stestr Cache
         uses: actions/cache@v3
@@ -240,6 +233,7 @@ jobs:
       - name: Nature Unit Tests under Python ${{ matrix.python-version }}
         uses: ./.github/actions/run-tests
         with:
+          os: ${{ matrix.os }}
           event-name: ${{ github.event_name }}
           run-slow: ${{ contains(github.event.pull_request.labels.*.name, 'run_slow') }}
           python-version: ${{ matrix.python-version }}
@@ -257,7 +251,7 @@ jobs:
           conda activate psi4env
           coverage3 combine
           mv .coverage ./ci-artifact-data/nat.dat
-        if: ${{ matrix.python-version == 3.7 }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8 }}
         shell: bash
       - uses: actions/upload-artifact@v3
         with:
@@ -372,16 +366,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/download-artifact@v3
-        with:
-          name: ubuntu-latest-3.7
-          path: /tmp/u37
       - uses: actions/download-artifact@v3
         with:
           name: ubuntu-latest-3.8
@@ -415,10 +405,10 @@ jobs:
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u37/nat.dep /tmp/u38/nat.dep /tmp/u39/nat.dep /tmp/u310/nat.dep /tmp/m39/nat.dep /tmp/m311/nat.dep /tmp/w38/nat.dep /tmp/w311/nat.dep || true
+          sort -f -u /tmp/u38/nat.dep /tmp/u39/nat.dep /tmp/u310/nat.dep /tmp/m39/nat.dep /tmp/m311/nat.dep /tmp/w38/nat.dep /tmp/w311/nat.dep || true
         shell: bash
       - name: Coverage combine
-        run: coverage3 combine /tmp/u37/nat.dat
+        run: coverage3 combine /tmp/u38/nat.dat
         shell: bash
       - name: Upload to Coveralls
         env:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,12 +1,12 @@
 queue_rules:
   - name: automerge
     conditions:
-      - check-success=Deprecation_Messages_and_Coverage (3.7)
+      - check-success=Deprecation_Messages_and_Coverage (3.8)
 
 pull_request_rules:
   - name: automatic merge on CI success and review
     conditions:
-      - check-success=Deprecation_Messages_and_Coverage (3.7)
+      - check-success=Deprecation_Messages_and_Coverage (3.8)
       - "#approved-reviews-by>=1"
       - label=automerge
       - label!=on hold

--- a/.pylintrc
+++ b/.pylintrc
@@ -378,4 +378,4 @@ analyse-fallback-blocks=no
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,3 @@
 numpy>=1.20.0
 ipython<8.13;python_version<'3.9'
-rustworkx!=0.13.0;python_version<'3.8'
 scipy<1.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311']

--- a/qiskit_nature/second_q/properties/protocols.py
+++ b/qiskit_nature/second_q/properties/protocols.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021, 2022.
+# (C) Copyright IBM 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/properties/protocols.py
+++ b/qiskit_nature/second_q/properties/protocols.py
@@ -14,18 +14,10 @@
 
 from __future__ import annotations
 
-from typing import Mapping
-
-import sys
+from typing import Mapping, Protocol, runtime_checkable
 
 import qiskit_nature  # pylint: disable=unused-import
 from qiskit_nature.second_q.operators import SparseLabelOp
-
-if sys.version_info >= (3, 8):
-    # pylint: disable=no-name-in-module
-    from typing import runtime_checkable, Protocol
-else:
-    from typing_extensions import runtime_checkable, Protocol
 
 
 @runtime_checkable
@@ -48,7 +40,7 @@ class Interpretable(Protocol):
     """
 
     def interpret(
-        self, result: "qiskit_nature.second_q.problemsEigenstateResult"  # type: ignore[name-defined]
+        self, result: "qiskit_nature.second_q.problems.EigenstateResult"  # type: ignore[name-defined]
     ) -> None:
         """Interprets an :class:`~qiskit_nature.second_q.problems.EigenstateResult`
         in the object's context.

--- a/releasenotes/notes/drop_python_3_7-35d42f30e19e7683.yaml
+++ b/releasenotes/notes/drop_python_3_7-35d42f30e19e7683.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Support for running with Python 3.7 has been removed. To run Nature you need
+    a minimum Python version of 3.8.

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -73,7 +72,7 @@ setuptools.setup(
     packages=setuptools.find_packages(include=["qiskit_nature", "qiskit_nature.*"]),
     install_requires=REQUIREMENTS,
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     extras_require={
         "pyscf": ["pyscf; sys_platform != 'win32'"],
         "mpl": ["matplotlib>=3.3"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3.0
-envlist = py37, py38, py39, py310, py311, lint
+envlist = py38, py39, py310, py311, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

CI nightly has been failing now for a while under 3.7 around mypy and rustworkx - the latter got updated to 0.13.1 and the constraint we had no longer worked. While I could have amended constraint, as Qiskit has now dropped support for 3.7 this drops it from Nature too, rendering the rustworkx constraint mute (which I removed), and means CI should now pass.

### Details and comments

A reno notes the upgrade needed for the user.

- [x] Once this passes we should amend the CI branch rules accordingly.

This should also allow #1222 to go forwards once merged.

I had meant to look for sys version checks and forgot (now done) - CI flagged a line no longer being tested and it turns out it was a version check. So I just removed this and what was needed for 3.7. This was protocols.py - I mused over changing the eigenstate result not to be a string - but there are other places where this could be done so Iet it be. I had noticed as the string was missing a period - which I fixed; I let that be the extent of the change otherwise.
