### PR TITLE
Fix deploy docs for python3 kernel missing

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,6 +35,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: |
+          pip install jupyter
           sudo apt-get install -y pandoc
         shell: bash
       - name: Install Nature
@@ -70,7 +71,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install torchvision tox
+          pip install jupyter torchvision tox
           sudo apt-get install -y pandoc
         shell: bash
       - name: Build and publish


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In running deploy docs on stable it failed. There was a change sometime back where this dependent not longer gets pulled in. The other app repos all install jupyter which installs this, and do not have the problem, so I added that here too. This will be needed for the next stable release so I changed it for main, but its needed now for the present stable, hence the backport label.

### Details and comments


