### PR TITLE
ci: test minimal Python version on Mac OS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,7 +150,7 @@ jobs:
         python-version: [3.8, 3.9, '3.10', 3.11]
         include:
           - os: macos-latest
-            python-version: 3.9
+            python-version: 3.8
           - os: macos-latest
             python-version: 3.11
           - os: windows-2019
@@ -374,8 +374,8 @@ jobs:
           path: /tmp/u310
       - uses: actions/download-artifact@v3
         with:
-          name: macos-latest-3.9
-          path: /tmp/m39
+          name: macos-latest-3.8
+          path: /tmp/m38
       - uses: actions/download-artifact@v3
         with:
           name: macos-latest-3.11
@@ -393,7 +393,7 @@ jobs:
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u38/nat.dep /tmp/u39/nat.dep /tmp/u310/nat.dep /tmp/m39/nat.dep /tmp/m311/nat.dep /tmp/w38/nat.dep /tmp/w311/nat.dep || true
+          sort -f -u /tmp/u38/nat.dep /tmp/u39/nat.dep /tmp/u310/nat.dep /tmp/m38/nat.dep /tmp/m311/nat.dep /tmp/w38/nat.dep /tmp/w311/nat.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/u38/nat.dat


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

I would like to make sure that we run our unittests for the lowest and highest supported Python versions on Mac OS and Windows, respectively.
We recently changed the tested Python version on Mac OS due to #1091. I would like to see if this is still needed.

### Details and comments

Since #1163 I cannot test this in my fork, hence the draft PR.
