### PR TITLE
feat: improve the implementation of the AngularMomentum operator

### DIFF
--- a/docs/apidocs/qiskit_nature.second_q.properties.s_operators.rst
+++ b/docs/apidocs/qiskit_nature.second_q.properties.s_operators.rst
@@ -1,0 +1,28 @@
+﻿
+
+s_operators
+=============================================
+
+.. automodule:: qiskit_nature.second_q.properties.s_operators
+
+   
+   
+   .. rubric:: Functions
+
+   .. autosummary::
+   
+      s_minus_operator
+      s_plus_operator
+      s_x_operator
+      s_y_operator
+      s_z_operator
+   
+   
+
+   
+   
+   
+
+   
+   
+   

--- a/qiskit_nature/second_q/properties/__init__.py
+++ b/qiskit_nature/second_q/properties/__init__.py
@@ -36,6 +36,14 @@ Electronic Properties
    Magnetization
    ParticleNumber
 
+The following submodule provides multiple functions which can be used to generator more modular
+spin-operator components.
+
+.. autosummary::
+   :toctree:
+
+   s_operators
+
 Vibrational Properties
 ----------------------
 

--- a/qiskit_nature/second_q/properties/s_operators.py
+++ b/qiskit_nature/second_q/properties/s_operators.py
@@ -1,0 +1,149 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Generator functions for various spin-related operators."""
+
+from __future__ import annotations
+
+from qiskit_nature.second_q.operators import FermionicOp
+
+
+def s_plus_operator(num_spatial_orbitals: int) -> FermionicOp:
+    r"""Constructs the $S^+$ operator.
+
+    The $S^+$ operator is defined as:
+
+    .. math::
+
+       S^+ = \sum_{i=1}^{n} \hat{a}_{i}^{\dagger} \hat{a}_{i+n}
+
+    Here, $n$ denotes the index of the *spatial* orbital. Since Qiskit Nature employs the blocked
+    spin-ordering convention, the creation operator above is applied to the :math:`\alpha`-spin
+    orbital and the annihilation operator is applied to the corresponding :math:`\beta`-spin
+    orbital.
+
+    Args:
+        num_spatial_orbitals: the size of the operator which to generate.
+
+    Returns:
+        The $S^+$ operator of the requested size.
+    """
+    op = FermionicOp(
+        {f"+_{orb} -_{orb + num_spatial_orbitals}": 1.0 for orb in range(num_spatial_orbitals)}
+    )
+    return op
+
+
+def s_minus_operator(num_spatial_orbitals: int) -> FermionicOp:
+    r"""Constructs the $S^-$ operator.
+
+    The $S^-$ operator is defined as:
+
+    .. math::
+
+       S^- = \sum_{i=1}^{n} \hat{a}_{i+n}^{\dagger} \hat{a}_{i}
+
+    Here, $n$ denotes the index of the *spatial* orbital. Since Qiskit Nature employs the blocked
+    spin-ordering convention, the creation operator above is applied to the :math:`\beta`-spin
+    orbital and the annihilation operator is applied to the corresponding :math:`\alpha`-spin
+    orbital.
+
+    Args:
+        num_spatial_orbitals: the size of the operator which to generate.
+
+    Returns:
+        The $S^-$ operator of the requested size.
+    """
+    op = FermionicOp(
+        {f"+_{orb + num_spatial_orbitals} -_{orb}": 1.0 for orb in range(num_spatial_orbitals)}
+    )
+    return op
+
+
+def s_x_operator(num_spatial_orbitals: int) -> FermionicOp:
+    r"""Constructs the $S^x$ operator.
+
+    The $S^x$ operator is defined as:
+
+    .. math::
+
+       S^x = \frac{1}{2} \left(S^+ + S^-\right)
+
+    Args:
+        num_spatial_orbitals: the size of the operator which to generate.
+
+    Returns:
+        The $S^x$ operator of the requested size.
+    """
+    op = FermionicOp(
+        {
+            f"+_{orb} -_{(orb + num_spatial_orbitals) % (2*num_spatial_orbitals)}": 0.5
+            for orb in range(2 * num_spatial_orbitals)
+        }
+    )
+    return op
+
+
+def s_y_operator(num_spatial_orbitals: int) -> FermionicOp:
+    r"""Constructs the $S^y$ operator.
+
+    The $S^y$ operator is defined as:
+
+    .. math::
+
+       S^y = -\frac{i}{2} \left(S^+ - S^-\right)
+
+    Args:
+        num_spatial_orbitals: the size of the operator which to generate.
+
+    Returns:
+        The $S^y$ operator of the requested size.
+    """
+    op = FermionicOp(
+        {
+            f"+_{orb} -_{(orb + num_spatial_orbitals) % (2*num_spatial_orbitals)}": 0.5j
+            * (-1.0) ** (orb < num_spatial_orbitals)
+            for orb in range(2 * num_spatial_orbitals)
+        }
+    )
+    return op
+
+
+def s_z_operator(num_spatial_orbitals: int) -> FermionicOp:
+    r"""Constructs the $S^z$ operator.
+
+    The $S^z$ operator is defined as:
+
+    .. math::
+
+       S^z = \frac{1}{2} \sum_{i=1}^{n} \left(
+        \hat{a}_{i}^{\dagger}\hat{a}_{i} - \hat{a}_{i+n}^{\dagger}\hat{a}_{i+n}
+       \right)
+
+    Here, $n$ denotes the index of the *spatial* orbital. Since Qiskit Nature employs the blocked
+    spin-ordering convention, this means that the above corresponds to evaluating the number
+    operator (:math:`\hat{a}^{\dagger}\hat{a}`) once on the :math:`\alpha`-spin orbital and once on
+    the :math:`\beta`-spin orbital and taking their difference.
+
+    Args:
+        num_spatial_orbitals: the size of the operator which to generate.
+
+    Returns:
+        The $S^z$ operator of the requested size.
+    """
+    op = FermionicOp(
+        {
+            f"+_{orb} -_{orb}": 0.5 * (-1.0) ** (orb >= num_spatial_orbitals)
+            for orb in range(2 * num_spatial_orbitals)
+        }
+    )
+    return op

--- a/releasenotes/notes/better-angular-momentum-9de340ef91d1024a.yaml
+++ b/releasenotes/notes/better-angular-momentum-9de340ef91d1024a.yaml
@@ -1,0 +1,21 @@
+---
+features:
+  - |
+    Adds new operator generator functions to allow more fine-grained spin observables.
+    The new functions are:
+
+    - the $S^+$ operator: :func:`.s_plus_operator`
+    - the $S^-$ operator: :func:`.s_minus_operator`
+    - the $S^x$ operator: :func:`.s_x_operator`
+    - the $S^y$ operator: :func:`.s_y_operator`
+    - the $S^z$ operator: :func:`.s_z_operator`
+
+    All of these functions take the number of spatial orbitals as their only argument
+    and return the constructed :class:`.FermionicOp`.
+
+    This also allows a much simpler implementation of the :class:`.AngularMomentum`
+    which is simply the $S^2$ operator:
+
+    .. math::
+
+       S^2 = S^- S^+ + S^z (S^z + 1)

--- a/test/second_q/properties/test_angular_momentum.py
+++ b/test/second_q/properties/test_angular_momentum.py
@@ -38,8 +38,9 @@ class TestAngularMomentum(PropertyTest):
             encoding="utf8",
         ) as file:
             expected = json.load(file)
-            expected_op = FermionicOp(expected, num_spin_orbitals=8).simplify()
-        self.assertEqual(op, expected_op)
+            expected_op = FermionicOp(expected, num_spin_orbitals=8)
+
+        self.assertEqual(op.normal_order(), expected_op.normal_order())
 
 
 if __name__ == "__main__":

--- a/test/second_q/properties/test_s_operators.py
+++ b/test/second_q/properties/test_s_operators.py
@@ -1,0 +1,107 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test the spin operator generator functions."""
+
+import unittest
+from test import QiskitNatureTestCase
+
+from qiskit_nature.second_q.operators import FermionicOp
+from qiskit_nature.second_q.operators.commutators import commutator
+from qiskit_nature.second_q.properties import AngularMomentum
+from qiskit_nature.second_q.properties.s_operators import (
+    s_minus_operator,
+    s_plus_operator,
+    s_x_operator,
+    s_y_operator,
+    s_z_operator,
+)
+
+
+class TestSOperators(QiskitNatureTestCase):
+    """Tests for the spin operator generator functions."""
+
+    def test_s_plus_operator(self) -> None:
+        """Tests the $S^+$ operator directly."""
+        truth = {f"+_{i} -_{i+4}": 1.0 for i in range(4)}
+        s_p = s_plus_operator(4)
+        self.assertEqual(s_p, FermionicOp(truth))
+
+    def test_s_minus_operator(self) -> None:
+        """Tests the $S^-$ operator directly."""
+        truth = {f"+_{i+4} -_{i}": 1.0 for i in range(4)}
+        s_m = s_minus_operator(4)
+        self.assertEqual(s_m, FermionicOp(truth))
+
+    def test_s_z_operator(self) -> None:
+        """Tests the $S^z$ operator directly."""
+        truth = {f"+_{i} -_{i}": 0.5 for i in range(4)}
+        truth.update({f"+_{i} -_{i}": -0.5 for i in range(4, 8)})
+        s_z = s_z_operator(4)
+        self.assertEqual(s_z, FermionicOp(truth))
+
+    def test_s_x_relation(self) -> None:
+        """Tests that :math:`S^x = 0.5 * (S^+ + S^-)`."""
+        s_x = s_x_operator(4)
+        s_p = s_plus_operator(4)
+        s_m = s_minus_operator(4)
+        self.assertEqual(s_x, 0.5 * (s_p + s_m))
+
+    def test_s_y_relation(self) -> None:
+        """Tests that :math:`S^y = -0.5j * (S^+ - S^-)`."""
+        s_y = s_y_operator(4)
+        s_p = s_plus_operator(4)
+        s_m = s_minus_operator(4)
+        self.assertEqual(s_y, -0.5j * (s_p - s_m))
+
+    def test_commutator_xyz(self) -> None:
+        """Tests that :math:`[S^x, S^y] = 1j * S^z`."""
+        s_x = s_x_operator(4)
+        s_y = s_y_operator(4)
+        s_z = s_z_operator(4)
+        self.assertEqual(commutator(s_x, s_y), 1j * s_z)
+
+    def test_commutator_yzx(self) -> None:
+        """Tests that :math:`[S^y, S^z] = 1j * S^x`."""
+        s_x = s_x_operator(4)
+        s_y = s_y_operator(4)
+        s_z = s_z_operator(4)
+        self.assertEqual(commutator(s_y, s_z), 1j * s_x)
+
+    def test_commutator_zxy(self) -> None:
+        """Tests that :math:`[S^z, S^x] = 1j * S^y`."""
+        s_x = s_x_operator(4)
+        s_y = s_y_operator(4)
+        s_z = s_z_operator(4)
+        self.assertEqual(commutator(s_z, s_x), 1j * s_y)
+
+    def test_commutator_s2x(self) -> None:
+        """Tests that :math:`[S^2, S^x] = 0`."""
+        s_x = s_x_operator(4)
+        s_2 = AngularMomentum(4).second_q_ops()["AngularMomentum"]
+        self.assertEqual(commutator(s_2, s_x), FermionicOp.zero())
+
+    def test_commutator_s2y(self) -> None:
+        """Tests that :math:`[S^2, S^y] = 0`."""
+        s_y = s_y_operator(4)
+        s_2 = AngularMomentum(4).second_q_ops()["AngularMomentum"]
+        self.assertEqual(commutator(s_2, s_y), FermionicOp.zero())
+
+    def test_commutator_s2z(self) -> None:
+        """Tests that :math:`[S^2, S^z] = 0`."""
+        s_z = s_z_operator(4)
+        s_2 = AngularMomentum(4).second_q_ops()["AngularMomentum"]
+        self.assertEqual(commutator(s_2, s_z), FermionicOp.zero())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The AngularMomentum operator is actually just the $S^2$ operator. However, in the code prior to this commit this was really not easy to follow.

Instead, this commit changes the implementation to rely on the sub-operators which the $S^2$ operator consists of. More specifically, it adds generator functions for the $S^+$ and $S^-$ ladder operators as well as the $S^x$, $S^y$, and $S^z$ operators. All of these may also be useful to users who want to evaluate these separately.

Unittests are added to assert the relations of all of these operators.
