### PR TITLE
Fix issue1258

### DIFF
--- a/qiskit_nature/second_q/operators/bosonic_op.py
+++ b/qiskit_nature/second_q/operators/bosonic_op.py
@@ -243,7 +243,7 @@ class BosonicOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key].sum()  # sum 0d numpy array to obtain scalar
+                data[""] = tensor[key].item()
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/bosonic_op.py
+++ b/qiskit_nature/second_q/operators/bosonic_op.py
@@ -243,7 +243,7 @@ class BosonicOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key]
+                data[""] = tensor[key].sum() # sum 0d numpy array to obtain scalar
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/bosonic_op.py
+++ b/qiskit_nature/second_q/operators/bosonic_op.py
@@ -243,7 +243,7 @@ class BosonicOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key].sum() # sum 0d numpy array to obtain scalar
+                data[""] = tensor[key].sum()  # sum 0d numpy array to obtain scalar
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -245,7 +245,7 @@ class FermionicOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key]
+                data[""] = tensor[key].sum() # sum 0d numpy array to obtain scalar
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -245,7 +245,7 @@ class FermionicOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key].sum()  # sum 0d numpy array to obtain scalar
+                data[""] = tensor[key].item()
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -245,7 +245,7 @@ class FermionicOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key].sum() # sum 0d numpy array to obtain scalar
+                data[""] = tensor[key].sum()  # sum 0d numpy array to obtain scalar
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/spin_op.py
+++ b/qiskit_nature/second_q/operators/spin_op.py
@@ -303,7 +303,7 @@ class SpinOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key]
+                data[""] = tensor[key].sum() # sum 0d numpy array to obtain scalar
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/spin_op.py
+++ b/qiskit_nature/second_q/operators/spin_op.py
@@ -303,7 +303,7 @@ class SpinOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key].sum()  # sum 0d numpy array to obtain scalar
+                data[""] = tensor[key].item()
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/spin_op.py
+++ b/qiskit_nature/second_q/operators/spin_op.py
@@ -303,7 +303,7 @@ class SpinOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key].sum() # sum 0d numpy array to obtain scalar
+                data[""] = tensor[key].sum()  # sum 0d numpy array to obtain scalar
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/vibrational_op.py
+++ b/qiskit_nature/second_q/operators/vibrational_op.py
@@ -300,7 +300,7 @@ class VibrationalOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key].sum()  # sum 0d numpy array to obtain scalar
+                data[""] = tensor[key].item()
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/vibrational_op.py
+++ b/qiskit_nature/second_q/operators/vibrational_op.py
@@ -300,7 +300,7 @@ class VibrationalOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key].sum() # sum 0d numpy array to obtain scalar
+                data[""] = tensor[key].sum()  # sum 0d numpy array to obtain scalar
                 continue
 
             mat = tensor[key]

--- a/qiskit_nature/second_q/operators/vibrational_op.py
+++ b/qiskit_nature/second_q/operators/vibrational_op.py
@@ -300,7 +300,7 @@ class VibrationalOp(SparseLabelOp):
 
         for key in tensor:
             if key == "":
-                data[""] = tensor[key]
+                data[""] = tensor[key].sum() # sum 0d numpy array to obtain scalar
                 continue
 
             mat = tensor[key]

--- a/releasenotes/notes/fix-from-polynomial-tensor-constant-9df7f63be4a4c819.yaml
+++ b/releasenotes/notes/fix-from-polynomial-tensor-constant-9df7f63be4a4c819.yaml
@@ -1,6 +1,7 @@
 ---
 fixes:
   - |
-    When using :meth:`.SparseLabelOp.from_polynomial_tensor` constructor for one of :class:`.BosonicOp`, :class:`.FermionicOp`,
-    :class:`.SpinOp`, or :class:`.VibrationalOp`, the coefficient for the constant term was a 0d Tensor object
-    rather than a number. This has been fixed.
+    When using :meth:`.SparseLabelOp.from_polynomial_tensor` constructor for one of
+    :class:`.BosonicOp`, :class:`.FermionicOp`, :class:`.SpinOp`, or :class:`.VibrationalOp`, the
+    coefficient for the constant term was a 0d Tensor object rather than a number. This has been
+    fixed.

--- a/releasenotes/notes/fix-from-polynomial-tensor-constant-9df7f63be4a4c819.yaml
+++ b/releasenotes/notes/fix-from-polynomial-tensor-constant-9df7f63be4a4c819.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    When using `from_polynomial_tensor` constructor for one of `BosonicOp`, `FermionicOp`,
-    `SpinOp`, or `VibrationalOp`, the coefficient for the constant term was a 0d Tensor object
+    When using :meth:`.SparseLabelOp.from_polynomial_tensor` constructor for one of :class:`.BosonicOp`, :class:`.FermionicOp`,
+    :class:`.SpinOp`, or :class:`.VibrationalOp`, the coefficient for the constant term was a 0d Tensor object
     rather than a number. This has been fixed.

--- a/releasenotes/notes/fix-from-polynomial-tensor-constant-9df7f63be4a4c819.yaml
+++ b/releasenotes/notes/fix-from-polynomial-tensor-constant-9df7f63be4a4c819.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    When using `from_polynomial_tensor` constructor for one of `BosonicOp`, `FermionicOp`,
+    `SpinOp`, or `VibrationalOp`, the coefficient for the constant term was a 0d Tensor object
+    rather than a number. This has been fixed.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes issue #1258 

For BosonicOp, FermionicOp, SpinOp, VibrationalOp, changed the line that takes care of the empty string coefficient (constant part of operator) in `from_polynomial_tensor` constructor to assign a scalar number rather than 0d array.

### Details and comments

PolynomialTensor stores all coefficients as tensors, including the empty string contribution, which is consistent. The SparseLabelOps have a scalar number coefficient per label string. When constructed from PolynomialTensor, coefficients are assigned from the scalar elements of the corresponding tensor. However, the constant term (empty string) is dealt with separately, assigning the 0d tensor:

```
data[""] = tensor[key]
```

To convert this also to scalar, this is replaced by:

```
data[""] = tensor[key].sum()
```
