### PR TITLE
Update CI PSI4 install

### DIFF
--- a/.github/actions/install-psi4/action.yml
+++ b/.github/actions/install-psi4/action.yml
@@ -31,10 +31,10 @@ runs:
         elif [[ "${{ inputs.os }}" == "macos-latest" ]]; then
           echo 'installs psi4 stable release'
           conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge
-          echo 'update intel-openmp'
-          conda update -y -c anaconda intel-openmp
-          echo 'update llvm-openmp'
-          conda update -y -c conda-forge llvm-openmp
+#          echo 'update intel-openmp'
+#          conda update -y -c anaconda intel-openmp
+#          echo 'update llvm-openmp'
+#          conda update -y -c conda-forge llvm-openmp
         else
           echo 'installs psi4 stable release'
           conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge

--- a/.github/actions/install-psi4/action.yml
+++ b/.github/actions/install-psi4/action.yml
@@ -27,16 +27,16 @@ runs:
         conda activate psi4env
         if [[ "${{ inputs.os }}" == "windows-latest" ]]; then
           echo "installs psi4 stable release"
-          conda install -y psi4 python=${{ inputs.python-version }} -c psi4 -c conda-forge
+          conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge
         elif [[ "${{ inputs.os }}" == "macos-latest" ]]; then
           echo 'installs psi4 stable release'
-          conda install -y psi4 python=${{ inputs.python-version }} -c psi4
+          conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge
           echo 'update intel-openmp'
           conda update -y -c anaconda intel-openmp
           echo 'update llvm-openmp'
           conda update -y -c conda-forge llvm-openmp
         else
           echo 'installs psi4 stable release'
-          conda install -y psi4 python=${{ inputs.python-version }} -c psi4
+          conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge
         fi
       shell: bash

--- a/.github/actions/install-psi4/action.yml
+++ b/.github/actions/install-psi4/action.yml
@@ -25,18 +25,6 @@ runs:
     - run : |
         source "$CONDA/etc/profile.d/conda.sh"
         conda activate psi4env
-        if [[ "${{ inputs.os }}" == "windows-latest" ]]; then
-          echo "installs psi4 stable release"
-          conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge
-        elif [[ "${{ inputs.os }}" == "macos-latest" ]]; then
-          echo 'installs psi4 stable release'
-          conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge
-          # echo 'update intel-openmp'
-          # conda update -y -c anaconda intel-openmp
-          # echo 'update llvm-openmp'
-          # conda update -y -c conda-forge llvm-openmp
-        else
-          echo 'installs psi4 stable release'
-          conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge
-        fi
+        echo "installs psi4 stable release"
+        conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge
       shell: bash

--- a/.github/actions/install-psi4/action.yml
+++ b/.github/actions/install-psi4/action.yml
@@ -31,10 +31,10 @@ runs:
         elif [[ "${{ inputs.os }}" == "macos-latest" ]]; then
           echo 'installs psi4 stable release'
           conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge
-#          echo 'update intel-openmp'
-#          conda update -y -c anaconda intel-openmp
-#          echo 'update llvm-openmp'
-#          conda update -y -c conda-forge llvm-openmp
+          # echo 'update intel-openmp'
+          # conda update -y -c anaconda intel-openmp
+          # echo 'update llvm-openmp'
+          # conda update -y -c conda-forge llvm-openmp
         else
           echo 'installs psi4 stable release'
           conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge

--- a/.github/actions/install-psi4/action.yml
+++ b/.github/actions/install-psi4/action.yml
@@ -27,7 +27,7 @@ runs:
         conda activate psi4env
         if [[ "${{ inputs.os }}" == "windows-latest" ]]; then
           echo "installs psi4 stable release"
-          conda install -y psi4 python=${{ inputs.python-version }} -c psi4
+          conda install -y psi4 python=${{ inputs.python-version }} -c psi4 -c conda-forge
         elif [[ "${{ inputs.os }}" == "macos-latest" ]]; then
           echo 'installs psi4 stable release'
           conda install -y psi4 python=${{ inputs.python-version }} -c psi4

--- a/.github/actions/install-psi4/action.yml
+++ b/.github/actions/install-psi4/action.yml
@@ -25,14 +25,12 @@ runs:
     - run : |
         source "$CONDA/etc/profile.d/conda.sh"
         conda activate psi4env
-        if [[ "${{ inputs.os }}" == "windows-2019" ]]; then
-          release=1.6
-          echo "installs psi4 release $release"
-          conda install -y psi4=$release python=${{ inputs.python-version }} -c psi4 -c conda-forge
+        if [[ "${{ inputs.os }}" == "windows-latest" ]]; then
+          echo "installs psi4 stable release"
+          conda install -y psi4 python=${{ inputs.python-version }} -c psi4
         elif [[ "${{ inputs.os }}" == "macos-latest" ]]; then
-          release=1.6
-          echo 'installs psi4 release $release'
-          conda install -y psi4=$release python=${{ inputs.python-version }} -c psi4
+          echo 'installs psi4 stable release'
+          conda install -y psi4 python=${{ inputs.python-version }} -c psi4
           echo 'update intel-openmp'
           conda update -y -c anaconda intel-openmp
           echo 'update llvm-openmp'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,9 +155,9 @@ jobs:
             python-version: 3.8
           - os: macos-latest
             python-version: 3.11
-          - os: windows-2019
+          - os: windows-latest
             python-version: 3.8
-          - os: windows-2019
+          - os: windows-latest
             python-version: 3.11
     steps:
       - uses: actions/checkout@v3
@@ -186,7 +186,6 @@ jobs:
         with:
           os: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
-        if: ${{ matrix.python-version != '3.11' && (matrix.os != 'windows-2019' || (matrix.os == 'windows-2019' && matrix.python-version != '3.11')) }}
       - uses: ./.github/actions/install-main-dependencies
         with:
           os: ${{ matrix.os }}
@@ -259,10 +258,8 @@ jobs:
           source "$CONDA/etc/profile.d/conda.sh"
           conda activate psi4env
           pip uninstall -y matplotlib pyscf sparse opt_einsum
-          if [[ "${{ matrix.python-version }}" != "3.11" && ("${{ matrix.os }}" != "windows-2019" || ("${{ matrix.os }}" == "windows-2019" && "${{ matrix.python-version }}" != "3.11")) ]]; then
-              echo 'Uninstall psi4'
-              conda remove -y --force psi4
-          fi
+          echo 'Uninstall psi4'
+          conda remove -y --force psi4
           if [ "${{ github.event_name }}" == "schedule" ] || [ "${{ contains(github.event.pull_request.labels.*.name, 'run_slow') }}" == "true" ]; then
               export QISKIT_TESTS="run_slow"
           fi
@@ -390,11 +387,11 @@ jobs:
           path: /tmp/m311
       - uses: actions/download-artifact@v3
         with:
-          name: windows-2019-3.8
+          name: windows-latest-3.8
           path: /tmp/w38
       - uses: actions/download-artifact@v3
         with:
-          name: windows-2019-3.11
+          name: windows-latest-3.11
           path: /tmp/w311
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Nightly tests seem to sometimes be failing around PSI4 with Windows and Python 3.8. CI is using Windows 2019 (not latest) and an older 1.6 PSI4. Newer versions of PSI4 are out there which also now support 3.11 so it can be installed there now too. I think part of using WIndows-2019 was that we used to build Aer and that was done in that platform.

Anyway this does two things, first changes to `windows-latest` instead of `windows-2019` (presently latest is windows-2022) and it removes the PSI4 1.6 specific version install to install whatever is the stable release, as well as installing it across the board (i.e. remove platform/version restrictions)

I will note the Windows and the default (Ubuntu) sections of the PSI4 install action now are the same, but I left them in separate blocks for now. I am unsure if the openmp updates are needed for Mac, but it seemed that could be done anyway so I left them. I want to see how this change fairs before thinking about possibly collapsing the blocks - though it does no harm to leave them as-is in case things need differentiating still (or in the future) - which is really why I did not already do this.

**_Update_**: In the end the openmp updates that were needed for the version Mac 3.8 was using is now not needed. The conda install was taken from https://psicode.org/installs/v182/ where its the same for all platforms. This works fine and now 3.11 CI includes PSI4 (for all platforms) where it did not before. Currently its installing 1.8.2 across the board versus 1.7 for ubuntu and 1.6 for windows & mac as things were. I simplified the psi4 install action to remove the if/then based on platform since the contents ended up all the same.

### Details and comments


