### PR TITLE
Update CODEOWNERS (again)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,11 +15,11 @@
 # review/merging of PRs in different subsections of the repository.
 
 # Global rule, unless specialized by a later one
-* @stefan-woerner @woodsp-ibm @mrossinek @robertodr @matteoacrossi
+* @woodsp-ibm @mrossinek @robertodr @matteoacrossi
 
 # Qiskit Nature modules
-mappers/  @stefan-woerner @woodsp-ibm @mrossinek @robertodr @matteoacrossi @ftroisi
-operators/  @stefan-woerner @woodsp-ibm @mrossinek @robertodr @matteoacrossi @ftroisi
+mappers/  @woodsp-ibm @mrossinek @robertodr @matteoacrossi @ftroisi
+operators/  @woodsp-ibm @mrossinek @robertodr @matteoacrossi @ftroisi
 
 # Override the release notes directories to have _no_ code owners, so any review
 # from somebody with write access is acceptable.


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

After reviewing the members of the `qiskit-nature` Github organization team, the only member without explicit other permissions in this repo was @stefan-woerner. Based on an offline discussion he agreed that his ownership and permissions are no longer required which is why I am removing him from this file. Subsequently, I will also remove the `qiskit-nature` team from the repository settings since we can rather add individual members in the future (rather than first adding everyone to the qiskit-community Github organization and subsequently a single team; since we will have less overlapping members across multiple repositories).

### Details and comments


