### PR TITLE
ci: update deploy-docs authorized users

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   docs_publish:
-    if: ${{ startsWith(github.ref, 'refs/heads/stable') && contains('["mtreinish","stefan-woerner","woodsp-ibm","mrossinek"]', github.actor) }}
+    if: ${{ startsWith(github.ref, 'refs/heads/stable') && contains('["mtreinish","woodsp-ibm","mrossinek","robertodr","matteoacrossi"]', github.actor) }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -56,7 +56,7 @@ jobs:
           tools/deploy_documentation.sh
         shell: bash
   deploy-translatable-strings:
-    if: ${{ startsWith(github.ref, 'refs/heads/stable') && contains('["mtreinish","stefan-woerner","woodsp-ibm","mrossinek"]', github.actor) }}
+    if: ${{ startsWith(github.ref, 'refs/heads/stable') && contains('["mtreinish","woodsp-ibm","mrossinek","robertodr","matteoacrossi"]', github.actor) }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In order to deploy the documentation to the public URL, a Github action needs to be triggered manually. In order to avoid anyone being able to do this, the script which is being run asserts the username of the `github.actor` to be in a hard-coded list of authorized users.

This commit updates this list in accordance with the recent CODEOWNER changes.

I believe, that there must be a better way to handle/restrict access to who can trigger this action, but for the time being I will simply do this quick fix.

### Details and comments


