### PR TITLE
UCC and fully occupied MOs (Fix for issue #1277)

### DIFF
--- a/qiskit_nature/second_q/circuit/library/ansatzes/ucc.py
+++ b/qiskit_nature/second_q/circuit/library/ansatzes/ucc.py
@@ -390,7 +390,7 @@ class UCC(EvolvedOperatorAnsatz):
                         f"(alpha, beta) particles."
                     )
                 return False
-                
+
             if any(n > self.num_spatial_orbitals for n in self.num_particles):
                 if raise_on_failure:
                     raise ValueError(

--- a/qiskit_nature/second_q/circuit/library/ansatzes/ucc.py
+++ b/qiskit_nature/second_q/circuit/library/ansatzes/ucc.py
@@ -381,7 +381,17 @@ class UCC(EvolvedOperatorAnsatz):
             return False
 
         if not self._generalized:
-            if any(n >= self.num_spatial_orbitals for n in self.num_particles):
+            if all(n == self.num_spatial_orbitals for n in self.num_particles):
+                if raise_on_failure:
+                    raise ValueError(
+                        f"UCC calculations for fully occupied alpha and beta orbitals "
+                        f"is still not implemented. The current system contains "
+                        f"{self.num_spatial_orbitals} orbitals for {self.num_particles} "
+                        f"(alpha, beta) particles."
+                    )
+                return False
+                
+            if any(n > self.num_spatial_orbitals for n in self.num_particles):
                 if raise_on_failure:
                     raise ValueError(
                         f"The number of spatial orbitals {self.num_spatial_orbitals} "

--- a/releasenotes/notes/fix-UCC-and-fully-occupied-MOs-c8fdf252a0607395.yaml
+++ b/releasenotes/notes/fix-UCC-and-fully-occupied-MOs-c8fdf252a0607395.yaml
@@ -1,6 +1,5 @@
 ---
 features:
   - |
-    Allow for building UCC
-    (:class:`qiskit_nature.second_q.circuit.library.ucc`) ansatze for systems
+    Allow for building :class:`.UCC` ansatze for systems
     where at least one of the spin registers is not fully occupied.

--- a/releasenotes/notes/fix-UCC-and-fully-occupied-MOs-c8fdf252a0607395.yaml
+++ b/releasenotes/notes/fix-UCC-and-fully-occupied-MOs-c8fdf252a0607395.yaml
@@ -1,12 +1,6 @@
 ---
-prelude: >
-    The UCC ansatz doesn't allow to calculate systems with either, or both of
-    the spin registers is fully occupied.
 features:
   - |
-    Allow for building UCC ansatze for systems where at least one of the spin
-    registers is not fully occupied.
-fixes:
-  - |
-    Fixes the :class:`qiskit_nature.second_q.circuit.library.ucc` to accept
-    systems with one spin register full.
+    Allow for building UCC
+    (:class:`qiskit_nature.second_q.circuit.library.ucc`) ansatze for systems
+    where at least one of the spin registers is not fully occupied.

--- a/releasenotes/notes/fix-UCC-and-fully-occupied-MOs-c8fdf252a0607395.yaml
+++ b/releasenotes/notes/fix-UCC-and-fully-occupied-MOs-c8fdf252a0607395.yaml
@@ -1,0 +1,12 @@
+---
+prelude: >
+    The UCC ansatz doesn't allow to calculate systems with either, or both of
+    the spin registers is fully occupied.
+features:
+  - |
+    Allow for building UCC ansatze for systems where at least one of the spin
+    registers is not fully occupied.
+fixes:
+  - |
+    Fixes the :class:`qiskit_nature.second_q.circuit.library.ucc` to accept
+    systems with one spin register full.

--- a/test/second_q/circuit/library/ansatzes/test_ucc.py
+++ b/test/second_q/circuit/library/ansatzes/test_ucc.py
@@ -121,7 +121,7 @@ class TestUCC(QiskitNatureTestCase):
             (2, 1),
             [
                 FermionicOp(
-                    {"+_2 -_3": 1j, "+_3 -_2": (-0-1j) },
+                    {"+_2 -_3": 1j, "+_3 -_2": (-0 - 1j)},
                     num_spin_orbitals=4,
                 )
             ],

--- a/test/second_q/circuit/library/ansatzes/test_ucc.py
+++ b/test/second_q/circuit/library/ansatzes/test_ucc.py
@@ -116,15 +116,15 @@ class TestUCC(QiskitNatureTestCase):
             ],
         ),
         (
-             # HeH molecule
-             "s",
-             2,
-             (2, 1),
-             [
-                  FermionicOp({"+_2 -_3": 1j, "+_3 -_2": (-0-1j) },
-                      num_spin_orbitals=4,
-                  )
-             ],
+            "s",
+            2,
+            (2, 1),
+            [
+                FermionicOp(
+                    {"+_2 -_3": 1j, "+_3 -_2": (-0-1j) },
+                    num_spin_orbitals=4,
+                )
+            ],
         ),
         # TODO: add more edge cases?
     )

--- a/test/second_q/circuit/library/ansatzes/test_ucc.py
+++ b/test/second_q/circuit/library/ansatzes/test_ucc.py
@@ -115,6 +115,17 @@ class TestUCC(QiskitNatureTestCase):
                 )
             ],
         ),
+        (
+             # HeH molecule
+             "s",
+             2,
+             (2, 1),
+             [
+                  FermionicOp({"+_2 -_3": 1j, "+_3 -_2": (-0-1j) },
+                      num_spin_orbitals=4,
+                  )
+             ],
+        ),
         # TODO: add more edge cases?
     )
     def test_ucc_ansatz(self, excitations, num_spatial_orbitals, num_particles, expect):


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Improved the functionality of UCC a little bit, to work if only one of the spin registers is fully occupied. 


### Details and comments
The configuration check looked for whether any number of alpha or beta orbitals (length of the spin register) was greater or equals than the number of particles.
Obviously, there cannot be more particles than spin orbitals, and in order to handle this case, I updated the previous `any(n >= ...` to `any(n > ...`. 
For handling case where **both** alpha and beta are the same as the number of particles (i.e. (2, 2) for the He2 molecule), I created a new raise condition, notifying that the function is still not implemented.
Implementing this option will probably involve dealing with the empty excitation list at line 339.
For the case where **either** alpha or beta is equals to the number of particles (i.e. H-He molecule), it should just pass through.

