### PR TITLE
fix: do not use `normal_order` as part of commutator methods

### DIFF
--- a/qiskit_nature/second_q/operators/commutators.py
+++ b/qiskit_nature/second_q/operators/commutators.py
@@ -45,7 +45,7 @@ def commutator(op_a: SparseLabelOp, op_b: SparseLabelOp) -> SparseLabelOp:
     Returns:
         The computed commutator.
     """
-    return (op_a @ op_b - op_b @ op_a).normal_order().simplify(atol=0)
+    return (op_a @ op_b - op_b @ op_a).simplify(atol=0)
 
 
 def anti_commutator(op_a: SparseLabelOp, op_b: SparseLabelOp) -> SparseLabelOp:
@@ -61,7 +61,7 @@ def anti_commutator(op_a: SparseLabelOp, op_b: SparseLabelOp) -> SparseLabelOp:
     Returns:
         The computed anti-commutator.
     """
-    return (op_a @ op_b + op_b @ op_a).normal_order().simplify(atol=0)
+    return (op_a @ op_b + op_b @ op_a).simplify(atol=0)
 
 
 def double_commutator(

--- a/qiskit_nature/second_q/operators/commutators.py
+++ b/qiskit_nature/second_q/operators/commutators.py
@@ -43,7 +43,8 @@ def commutator(op_a: SparseLabelOp, op_b: SparseLabelOp) -> SparseLabelOp:
         op_b: Operator B.
 
     Returns:
-        The computed commutator.
+        The computed commutator. If available for your kind of operator, you may want to
+        ``normal_order()`` it.
     """
     return (op_a @ op_b - op_b @ op_a).simplify(atol=0)
 
@@ -59,7 +60,8 @@ def anti_commutator(op_a: SparseLabelOp, op_b: SparseLabelOp) -> SparseLabelOp:
         op_b: Operator B.
 
     Returns:
-        The computed anti-commutator.
+        The computed anti--commutator. If available for your kind of operator, you may want to
+        ``normal_order()`` it.
     """
     return (op_a @ op_b + op_b @ op_a).simplify(atol=0)
 

--- a/releasenotes/notes/fix-commutator-methods-fdae69426a05222a.yaml
+++ b/releasenotes/notes/fix-commutator-methods-fdae69426a05222a.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The commutator methods were faultily trying to call ``normal_order()`` on
+    their operands, which are not guaranteed to have this method. Now, they no
+    longer call this method and instead it is up to the user to normal-order the
+    result as needed.

--- a/test/second_q/operators/test_bosonic_op.py
+++ b/test/second_q/operators/test_bosonic_op.py
@@ -246,15 +246,15 @@ class TestBosonicOp(QiskitNatureTestCase):
         with self.subTest("commutator same index"):
             bos_op = commutator(BosonicOp({"-_0": 1}), BosonicOp({"+_0": 1}))
             targ = BosonicOp({"": 1})
-            self.assertEqual(bos_op, targ)
+            self.assertEqual(bos_op.normal_order(), targ)
         with self.subTest("commutator same index reversed"):
             bos_op = commutator(BosonicOp({"+_0": 1}), BosonicOp({"-_0": 1}))
             targ = BosonicOp({"": -1})
-            self.assertEqual(bos_op, targ)
+            self.assertEqual(bos_op.normal_order(), targ)
         with self.subTest("commutator same different indices"):
             bos_op = commutator(BosonicOp({"+_0": 1}), BosonicOp({"-_1": 1}))
             targ = BosonicOp({})  # 0
-            self.assertEqual(bos_op, targ)
+            self.assertEqual(bos_op.normal_order(), targ)
 
     def test_compose(self):
         """Test operator composition

--- a/test/second_q/operators/test_commutators.py
+++ b/test/second_q/operators/test_commutators.py
@@ -40,7 +40,7 @@ class TestCommutators(QiskitNatureTestCase):
     @unpack
     @data(
         (op1, op2, {}),
-        (op4, op5, {"+_0 -_0": (2 + 0j), "": (-1 + 0j)}),
+        (op4, op5, {"+_0 -_0": (1 + 0j), "-_0 +_0": (-1 + 0j)}),
     )
     def test_commutator(self, op_a: FermionicOp, op_b: FermionicOp, expected: dict):
         """Test commutator method"""

--- a/test/second_q/properties/test_s_operators.py
+++ b/test/second_q/properties/test_s_operators.py
@@ -74,39 +74,39 @@ class TestSOperators(QiskitNatureTestCase):
         s_x = s_x_operator(4)
         s_y = s_y_operator(4)
         s_z = s_z_operator(4)
-        self.assertEqual(commutator(s_x, s_y), 1j * s_z)
+        self.assertEqual(commutator(s_x, s_y).normal_order(), 1j * s_z)
 
     def test_commutator_yzx(self) -> None:
         """Tests that :math:`[S^y, S^z] = 1j * S^x`."""
         s_x = s_x_operator(4)
         s_y = s_y_operator(4)
         s_z = s_z_operator(4)
-        self.assertEqual(commutator(s_y, s_z), 1j * s_x)
+        self.assertEqual(commutator(s_y, s_z).normal_order(), 1j * s_x)
 
     def test_commutator_zxy(self) -> None:
         """Tests that :math:`[S^z, S^x] = 1j * S^y`."""
         s_x = s_x_operator(4)
         s_y = s_y_operator(4)
         s_z = s_z_operator(4)
-        self.assertEqual(commutator(s_z, s_x), 1j * s_y)
+        self.assertEqual(commutator(s_z, s_x).normal_order(), 1j * s_y)
 
     def test_commutator_s2x(self) -> None:
         """Tests that :math:`[S^2, S^x] = 0`."""
         s_x = s_x_operator(4)
         s_2 = AngularMomentum(4).second_q_ops()["AngularMomentum"]
-        self.assertEqual(commutator(s_2, s_x), FermionicOp.zero())
+        self.assertEqual(commutator(s_2, s_x).normal_order(), FermionicOp.zero())
 
     def test_commutator_s2y(self) -> None:
         """Tests that :math:`[S^2, S^y] = 0`."""
         s_y = s_y_operator(4)
         s_2 = AngularMomentum(4).second_q_ops()["AngularMomentum"]
-        self.assertEqual(commutator(s_2, s_y), FermionicOp.zero())
+        self.assertEqual(commutator(s_2, s_y).normal_order(), FermionicOp.zero())
 
     def test_commutator_s2z(self) -> None:
         """Tests that :math:`[S^2, S^z] = 0`."""
         s_z = s_z_operator(4)
         s_2 = AngularMomentum(4).second_q_ops()["AngularMomentum"]
-        self.assertEqual(commutator(s_2, s_z), FermionicOp.zero())
+        self.assertEqual(commutator(s_2, s_z).normal_order(), FermionicOp.zero())
 
 
 class TestSOperatorsWithOverlap(QiskitNatureTestCase):


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #1298

### Details and comments

In #1208 we had discussed the inclusion of `normal_order` into the commutator methods without realizing that this breaks API. Here, I simply remove this call and update the unittests accordingly.
Basically, this means that the user needs to normal-order the result themselves if needed (which is totally fine).