### PR TITLE
Fix CI mypy for compatibility with latest rustworkx

### DIFF
--- a/qiskit_nature/second_q/hamiltonians/lattices/hexagonal_lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/hexagonal_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from rustworkx import generators  # type: ignore[attr-defined]
+from rustworkx import generators
 
 from .lattice import Lattice
 

--- a/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
+++ b/qiskit_nature/second_q/hamiltonians/lattices/lattice.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -22,7 +22,7 @@ import numbers
 import numpy as np
 
 from rustworkx import NodeIndices, PyGraph, WeightedEdgeList
-from rustworkx import adjacency_matrix, networkx_converter  # type: ignore[attr-defined]
+from rustworkx import adjacency_matrix, networkx_converter
 from rustworkx.visualization import mpl_draw
 
 from qiskit.utils import optionals as _optionals

--- a/test/second_q/hamiltonians/lattices/test_hexagonal_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_hexagonal_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import HexagonalLattice
 
 

--- a/test/second_q/hamiltonians/lattices/test_hyper_cubic_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_hyper_cubic_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     HyperCubicLattice,

--- a/test/second_q/hamiltonians/lattices/test_kagome_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_kagome_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,7 +15,7 @@ import unittest
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     KagomeLattice,

--- a/test/second_q/hamiltonians/lattices/test_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
+from rustworkx import PyGraph, is_isomorphic
 
 from qiskit.utils import optionals as _optionals
 

--- a/test/second_q/hamiltonians/lattices/test_line_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_line_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     LineLattice,

--- a/test/second_q/hamiltonians/lattices/test_square_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_square_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     SquareLattice,

--- a/test/second_q/hamiltonians/lattices/test_triangular_lattice.py
+++ b/test/second_q/hamiltonians/lattices/test_triangular_lattice.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,7 +14,7 @@
 from test import QiskitNatureTestCase
 from numpy.testing import assert_array_equal
 import numpy as np
-from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import (
     BoundaryCondition,
     TriangularLattice,

--- a/test/second_q/hamiltonians/test_fermi_hubbard_model.py
+++ b/test/second_q/hamiltonians/test_fermi_hubbard_model.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -15,7 +15,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
+from rustworkx import PyGraph, is_isomorphic
 
 from qiskit_nature.second_q.hamiltonians import FermiHubbardModel
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice

--- a/test/second_q/hamiltonians/test_heisenberg_model.py
+++ b/test/second_q/hamiltonians/test_heisenberg_model.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,7 +13,7 @@
 """Test HeisenbergModel."""
 
 from test import QiskitNatureTestCase
-from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
+from rustworkx import PyGraph, is_isomorphic
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice, LineLattice
 from qiskit_nature.second_q.hamiltonians import HeisenbergModel, IsingModel
 

--- a/test/second_q/hamiltonians/test_ising_model.py
+++ b/test/second_q/hamiltonians/test_ising_model.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -16,7 +16,7 @@ from test import QiskitNatureTestCase
 
 import numpy as np
 from numpy.testing import assert_array_equal
-from rustworkx import PyGraph, is_isomorphic  # type: ignore[attr-defined]
+from rustworkx import PyGraph, is_isomorphic
 
 from qiskit_nature.second_q.hamiltonians.lattices import Lattice
 from qiskit_nature.second_q.hamiltonians import IsingModel


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #1309

Version 0.14.0 of [rustworkx](https://www.rustworkx.org/) was recently released and [added type annotations](https://www.rustworkx.org/release_notes.html#relnotes-0-14-0)

> 0.14.0
> Prelude
>
> This is a new feature release of Rustworkx that adds many new features to the library. The highlights of this release are:
>
>    *  Fully type annotated for support with [mypy](https://mypy-lang.org/) and other tooling

In places a type ignore has previously been needed, but as noted in #1309, it now failing as the ignore is unnecessary and unused.

### Details and comments

Removes the type ignore comments from the places where it no longer needed.
