### PR TITLE
Update intersphinx links and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The code comprises various modules revolving around:
 - translating from the second-quantized to the qubit space
 - a quantum circuit library of natural science targeted ansatze
 - natural science specific algorithms and utilities to make the use of
-  algorithms from [Qiskit Algorithms](https://qiskit.org/ecosystem/algorithms/) easier
+  algorithms from [Qiskit Algorithms](https://qiskit-community.github.io/qiskit-algorithms/) easier
 - and much more
 
 ## Installation
@@ -33,7 +33,7 @@ pip install qiskit-nature
 If you want to work on the very latest work-in-progress versions, either to try features ahead of
 their official release or if you want to contribute to Qiskit Nature, then you can install from source.
 To do this follow the instructions in the
- [documentation](https://qiskit.org/ecosystem/nature/getting_started.html#installation).
+ [documentation](https://qiskit-community.github.io/qiskit-nature/getting_started.html#installation).
 
 ### Optional Installs
 
@@ -43,9 +43,9 @@ Several, as listed below, are supported, and while logic to interface these prog
 Qiskit Nature via the above pip installation, the dependent programs/libraries themselves need
 to be installed separately.
 
-- [Gaussian 16&trade;](https://qiskit.org/ecosystem/nature/apidocs/qiskit_nature.second_q.drivers.gaussiand.html), a commercial chemistry program
-- [PSI4](https://qiskit.org/ecosystem/nature/apidocs/qiskit_nature.second_q.drivers.psi4d.html), a chemistry program that exposes a Python interface allowing for accessing internal objects
-- [PySCF](https://qiskit.org/ecosystem/nature/apidocs/qiskit_nature.second_q.drivers.pyscfd.html), an open-source Python chemistry program
+- [Gaussian 16&trade;](https://qiskit-community.github.io/qiskit-nature/apidocs/qiskit_nature.second_q.drivers.gaussiand.html), a commercial chemistry program
+- [PSI4](https://qiskit-community.github.io/qiskit-nature/apidocs/qiskit_nature.second_q.drivers.psi4d.html), a chemistry program that exposes a Python interface allowing for accessing internal objects
+- [PySCF](https://qiskit-community.github.io/qiskit-nature/apidocs/qiskit_nature.second_q.drivers.pyscfd.html), an open-source Python chemistry program
 
 The above codes can be used in a very limited fashion through Qiskit Nature.
 While this is useful for getting started and testing purposes, a better experience can be had in the reversed order of responsibility.
@@ -63,13 +63,13 @@ Additionally, you may find the following optional dependencies useful:
 
 ## Creating Your First Chemistry Programming Experiment in Qiskit
 
-Check our [getting started page](https://qiskit.org/ecosystem/nature/getting_started.html)
+Check our [getting started page](https://qiskit-community.github.io/qiskit-nature/getting_started.html)
 for a first example on how to use Qiskit Nature.
 
 ### Further examples
 
 Learning path notebooks may be found in the
-[Nature Tutorials](https://qiskit.org/ecosystem/nature/tutorials/index.html) section
+[Nature Tutorials](https://qiskit-community.github.io/qiskit-nature/tutorials/index.html) section
 of the documentation and are a great place to start.
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,9 +192,9 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "qiskit": ("https://qiskit.org/documentation/", None),
-    "qiskit-algorithms": ("https://qiskit.org/ecosystem/algorithms/", None),
-    "rustworkx": ("https://qiskit.org/ecosystem/rustworkx/", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit-algorithms": ("https://qiskit-community.github.io/qiskit-algorithms/", None),
+    "rustworkx": ("https://www.rustworkx.org/", None),
     "sparse": ("https://sparse.pydata.org/en/stable/", None),
 }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ The code comprises various modules revolving around:
 - translating from the second-quantized to the qubit space
 - a quantum circuit library of natural science targeted ansatze
 - natural science specific algorithms and utilities to make the use of
-  algorithms from `Qiskit Algorithms <https://qiskit.org/ecosystem/algorithms/>`_ easier
+  algorithms from `Qiskit Algorithms <https://qiskit-community.github.io/qiskit-algorithms/>`_ easier
 - and much more
 
 

--- a/docs/tutorials/03_ground_state_solvers.ipynb
+++ b/docs/tutorials/03_ground_state_solvers.ipynb
@@ -127,7 +127,7 @@
     "\n",
     "1. An Estimator primitive: these were released as part of Qiskit Terra 0.22. To learn more about primitives, check out [this resource](https://qiskit.org/documentation/apidoc/primitives.html).\n",
     "2. A variational form: here we use the Unitary Coupled Cluster (UCC) ansatz (see for instance [Physical Review A 98.2 (2018): 022322]). Since it is a chemistry standard, a factory is already available allowing a fast initialization of a VQE with UCC. The default is to use all single and double excitations. However, the excitation type (S, D, SD) as well as other parameters can be selected. We also prepend the `UCCSD` variational form with a `HartreeFock` initial state, which initializes the occupation of our qubits according to the problem which we are trying solve.\n",
-    "3. An optimizer: this is the classical piece of code in charge of optimizing the parameters in our variational form. See [the corresponding documentation](https://qiskit.org/ecosystem/algorithms/apidocs/qiskit_algorithms.optimizers.html) for more information.\n",
+    "3. An optimizer: this is the classical piece of code in charge of optimizing the parameters in our variational form. See [the corresponding documentation](https://qiskit-community.github.io/qiskit-algorithms/apidocs/qiskit_algorithms.optimizers.html) for more information.\n",
     "\n",
     "One could also use any available ansatz / initial state or even define one's own. For instance,"
    ]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2023.
+# (C) Copyright IBM 2018, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setuptools.setup(
     },
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit-nature/issues",
-        "Documentation": "https://qiskit.org/ecosystem/nature/",
+        "Documentation": "https://qiskit-community.github.io/qiskit-nature/",
         "Source Code": "https://github.com/Qiskit/qiskit-nature",
     },
     zip_safe=False,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates links away from qiskit.org to the new locations for the docs

Fixes #1304
Fixes #1305

### Details and comments

Now that all the applications and the algorithms docs are deployed on github pages this updates the intersphinx links, in conf.py, and also urls that are coded directly in other places such as the readme and tutorials. I did not alter past release notes. There is a redirect now in effect for the former location on `qiskit.org/ecosystem` so they get to the right place.

Note that the current theme is still emitting a link to qiskit.org/ecosystem, but that will get redirected for now until such time as Qiskit/qiskit_sphinx_theme#588 is resolved and new docs are generated with such an updated theme and re-deployed.

