### PR TITLE
Add slow_test as it's no longer part of Qiskit 1.0

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -194,6 +194,7 @@ formatter
 fortran
 fp
 fredkin
+func
 functionalities
 für
 gauopen

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2018, 2023.
+# (C) Copyright IBM 2018, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -12,6 +12,7 @@
 
 """ Qiskit Nature test packages """
 
+from .decorators import slow_test
 from .nature_test_case import QiskitNatureTestCase
 
-__all__ = ["QiskitNatureTestCase"]
+__all__ = ["QiskitNatureTestCase", "slow_test"]

--- a/test/decorators.py
+++ b/test/decorators.py
@@ -1,0 +1,37 @@
+# This code is part of a Qiskit project.
+#
+# (C) Copyright IBM 2017, 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+"""Decorator for using with unit tests."""
+
+import functools
+import os
+import unittest
+
+
+def slow_test(func):
+    """Decorator that signals that the test takes minutes to run.
+
+    Args:
+        func (callable): test function to be decorated.
+
+    Returns:
+        callable: the decorated function.
+    """
+
+    @functools.wraps(func)
+    def _wrapper(*args, **kwargs):
+        if "run_slow" in os.environ.get("QISKIT_TESTS", ""):
+            raise unittest.SkipTest("Skipping slow tests")
+        return func(*args, **kwargs)
+
+    return _wrapper

--- a/test/second_q/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
+++ b/test/second_q/algorithms/ground_state_solvers/test_advanced_ucc_variants.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,13 +14,12 @@
 
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureTestCase, slow_test
 
 from qiskit_algorithms import VQE
 from qiskit_algorithms.optimizers import SLSQP
 from qiskit_algorithms.utils import algorithm_globals
 from qiskit.primitives import Estimator
-from qiskit.test import slow_test
 
 from qiskit_nature.second_q.algorithms import GroundStateEigensolver
 from qiskit_nature.second_q.circuit.library import HartreeFock, SUCCD, PUCCD

--- a/test/second_q/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
+++ b/test/second_q/algorithms/ground_state_solvers/test_groundstate_eigensolver.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2023.
+# (C) Copyright IBM 2020, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -17,7 +17,7 @@ import copy
 import io
 import unittest
 
-from test import QiskitNatureTestCase
+from test import QiskitNatureTestCase, slow_test
 
 import numpy as np
 
@@ -25,7 +25,6 @@ from qiskit_algorithms import NumPyMinimumEigensolver, VQE
 from qiskit_algorithms.optimizers import SLSQP, SPSA
 from qiskit_algorithms.utils import algorithm_globals
 from qiskit.primitives import Estimator
-from qiskit.test import slow_test
 
 import qiskit_nature.optionals as _optionals
 from qiskit_nature.second_q.algorithms import GroundStateEigensolver

--- a/test/second_q/algorithms/ground_state_solvers/test_swaprz.py
+++ b/test/second_q/algorithms/ground_state_solvers/test_swaprz.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,14 +13,13 @@
 """Test of ExcitationPreserving from the circuit library."""
 
 import unittest
-from test import QiskitNatureTestCase
+from test import QiskitNatureTestCase, slow_test
 
 from qiskit_algorithms import VQE
 from qiskit_algorithms.optimizers import SLSQP
 from qiskit_algorithms.utils import algorithm_globals
 from qiskit.primitives import Estimator
 from qiskit.circuit.library import ExcitationPreserving
-from qiskit.test import slow_test
 import qiskit_nature.optionals as _optionals
 from qiskit_nature.second_q.algorithms import GroundStateEigensolver
 from qiskit_nature.second_q.circuit.library import HartreeFock

--- a/test/second_q/drivers/pyscfd/test_driver_methods_pyscf.py
+++ b/test/second_q/drivers/pyscfd/test_driver_methods_pyscf.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2019, 2023.
+# (C) Copyright IBM 2019, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,9 +14,10 @@
 
 import unittest
 
+from test import slow_test
 from test.second_q.drivers.test_driver_methods_gsc import TestDriverMethods
+
 from qiskit.quantum_info import Statevector
-from qiskit.test import slow_test
 from qiskit_nature.second_q.circuit.library import HartreeFock
 from qiskit_nature.units import DistanceUnit
 from qiskit_nature.second_q.drivers import PySCFDriver, MethodType


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`slow_test` used to be part of qiskit.test but the whole test folder was removed for Qiskit 1.0. This adds a copy of that slow_test decorator locally so that things continue working and of course will still work with 0.45 and 0.46 where its deprecated.

Same change as done in qiskit-community/qiskit-algorithms#141

### Details and comments

(This seems to be the only apps repo that uses slow_test. I could not find any uses in ML, Opt or Fin.)
