### PR TITLE
Update Qiskit parallel map usage and remove TextProgressBar

### DIFF
--- a/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom.py
+++ b/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2020, 2023.
+# (C) Copyright IBM 2020, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -28,8 +28,6 @@ from qiskit_algorithms import EigensolverResult, MinimumEigensolver
 from qiskit_algorithms.list_or_dict import ListOrDict as ListOrDictType
 from qiskit_algorithms.observables_evaluator import estimate_observables
 from qiskit.circuit import QuantumCircuit
-from qiskit.tools import parallel_map
-from qiskit.tools.events import TextProgressBar
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.primitives import BaseEstimator
 
@@ -46,6 +44,7 @@ from qiskit_nature.second_q.problems import (
     EigenstateResult,
     ElectronicStructureResult,
 )
+from qiskit_nature.utils import _parallel_map
 
 from .qeom_electronic_ops_builder import build_electronic_ops
 from .qeom_vibrational_ops_builder import build_vibrational_ops
@@ -496,9 +495,8 @@ class QEOM(ExcitedStatesSolver):
 
         if logger.isEnabledFor(logging.INFO):
             logger.info("Building all commutators:")
-            TextProgressBar(sys.stderr)
 
-        results = parallel_map(
+        results = _parallel_map(
             self._build_commutator_routine,
             to_be_computed_list,
             task_args=(untap_operator,),

--- a/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom.py
+++ b/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom.py
@@ -18,7 +18,6 @@ from typing import Any, Callable, Sequence
 from enum import Enum
 import itertools
 import logging
-import sys
 
 
 import numpy as np

--- a/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom_electronic_ops_builder.py
+++ b/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom_electronic_ops_builder.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -17,12 +17,12 @@ from __future__ import annotations
 from typing import Callable
 
 from qiskit.quantum_info import SparsePauliOp
-from qiskit.tools import parallel_map
 
 from qiskit_nature import QiskitNatureError
 from qiskit_nature.second_q.circuit.library import UCC
 from qiskit_nature.second_q.operators import FermionicOp
 from qiskit_nature.second_q.mappers import QubitMapper, TaperedQubitMapper
+from qiskit_nature.utils import _parallel_map
 
 
 def build_electronic_ops(
@@ -81,7 +81,7 @@ def build_electronic_ops(
         excitation_indices[f"E_{idx}"] = excitations_list[idx]
         excitation_indices[f"Edag_{idx}"] = excitations_list[idx][::-1]
 
-    result = parallel_map(
+    result = _parallel_map(
         _build_single_hopping_operator,
         to_be_executed_list,
         task_args=(num_spatial_orbitals, qubit_mapper),

--- a/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom_vibrational_ops_builder.py
+++ b/qiskit_nature/second_q/algorithms/excited_states_solvers/qeom_vibrational_ops_builder.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -17,11 +17,11 @@ from __future__ import annotations
 from typing import Callable
 
 from qiskit.quantum_info import SparsePauliOp
-from qiskit.tools import parallel_map
 
 from qiskit_nature.second_q.circuit.library import UVCC
 from qiskit_nature.second_q.operators import VibrationalOp
 from qiskit_nature.second_q.mappers import QubitMapper, TaperedQubitMapper
+from qiskit_nature.utils import _parallel_map
 
 
 def build_vibrational_ops(
@@ -70,7 +70,7 @@ def build_vibrational_ops(
         excitation_indices[f"E_{idx}"] = excitations_list[idx]
         excitation_indices[f"Edag_{idx}"] = excitations_list[idx][::-1]
 
-    result = parallel_map(
+    result = _parallel_map(
         _build_single_hopping_operator,
         to_be_executed_list,
         task_args=(num_modals, qubit_mapper),

--- a/qiskit_nature/utils/__init__.py
+++ b/qiskit_nature/utils/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -28,6 +28,7 @@ Linear algebra utilities
    double_factorized
    modified_cholesky
 """
+import warnings
 
 from .linalg import (
     apply_matrix_to_slices,
@@ -36,6 +37,17 @@ from .linalg import (
     modified_cholesky,
 )
 from .opt_einsum import get_einsum
+
+# Handles import for use of Qiskit parallel map to cater to location before
+# and after the 1.0 version
+try:
+    # From 0.46 onwards parallel map is here
+    from qiskit.utils import parallel_map as _parallel_map
+except ImportError:
+    # Until 0.46 it's here but in 0.46 raises a deprecation
+    # using it at this older location, hence we try the new
+    # location first above and only then fallback to the old here
+    from qiskit.tools import parallel_map as _parallel_map
 
 __all__ = [
     "apply_matrix_to_slices",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #1314
Closes #1324

### Details and comments

I updated the code to import the `parallel_map` into qiskit_nature.utils and expose it as `_parallel_map` to avoid creating a new public method as such. The import tries in the new location, which exists from 0.46 and above, before it goes back to the former location. The former location still exists in 0.46 but raises a deprecation warning hence the order of trying the imports to avoid this.

We could update the min requirements of Qiskit to 0.46 to avoid this and directly import/use parallel map from the new location. I chose the path of broader compatibility and did not update requirements as 0.46 is not quite yet released.

I completely removed TextProgressBar usage as TextProgressBar is removed in 1.0.

Tests all pass locally on my machine where I have the main branch with what will end up in 1.0 installed. It also works with 0.45 as I tried that too as that s currently what CI is using until a newer version gets released. **Update**: 0.46 has since been released, nightly CI is now failing.

As parallel map is internal logic that was changed, and TextProgressBar just affects what comes out in logs if enabled, neither change warrants a release note I think, so I did not include any.

