### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,10 @@ jobs:
           fi
           source "$CONDA/etc/profile.d/conda.sh"
           if [ "${{ matrix.python-version }}" >= "3.11" ]; then
-            conda create -y -n psi4env python=${{ matrix.python-version }} -c conda-forge
+            if [ "${{ matrix.python-version }}" == "3.11" ]; then
+              conda create -y -n psi4env python=${{ matrix.python-version }} -c conda-forge
+            else
+              conda create -y -n psi4env python=3.12 -c conda-forge
           else
             conda create -y -n psi4env python=${{ matrix.python-version }}
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,11 +175,10 @@ jobs:
             sudo chown -R $USER: "$CONDA"
           fi
           source "$CONDA/etc/profile.d/conda.sh"
-          if [ "${{ matrix.python-version }}" >= "3.11" ]; then
-            if [ "${{ matrix.python-version }}" == "3.11" ]; then
-              conda create -y -n psi4env python=${{ matrix.python-version }} -c conda-forge
-            else
-              conda create -y -n psi4env python=3.12 -c conda-forge
+          if [ "${{ matrix.python-version }}" == "3.11" ]; then
+            conda create -y -n psi4env python=${{ matrix.python-version }} -c conda-forge
+          elif [ "${{ matrix.python-version }}" == "3.12.0" ]; then
+            conda create -y -n psi4env python=3.12 -c conda-forge
           else
             conda create -y -n psi4env python=${{ matrix.python-version }}
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -149,16 +149,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9, '3.10', 3.11]
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12.0]
         include:
           - os: macos-latest
             python-version: 3.8
           - os: macos-latest
-            python-version: 3.11
+            python-version: 3.12.0
           - os: windows-latest
             python-version: 3.8
           - os: windows-latest
-            python-version: 3.11
+            python-version: 3.12.0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -175,7 +175,7 @@ jobs:
             sudo chown -R $USER: "$CONDA"
           fi
           source "$CONDA/etc/profile.d/conda.sh"
-          if [ "${{ matrix.python-version }}" == "3.11" ]; then
+          if [ "${{ matrix.python-version }}" >= "3.11" ]; then
             conda create -y -n psi4env python=${{ matrix.python-version }} -c conda-forge
           else
             conda create -y -n psi4env python=${{ matrix.python-version }}
@@ -274,7 +274,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.11]
+        python-version: [3.8, 3.12]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -379,26 +379,30 @@ jobs:
           path: /tmp/u311
       - uses: actions/download-artifact@v4
         with:
+          name: ubuntu-latest-3.12.0
+          path: /tmp/u312
+      - uses: actions/download-artifact@v4
+        with:
           name: macos-latest-3.8
           path: /tmp/m38
       - uses: actions/download-artifact@v4
         with:
-          name: macos-latest-3.11
-          path: /tmp/m311
+          name: macos-latest-3.12.0
+          path: /tmp/m312
       - uses: actions/download-artifact@v4
         with:
           name: windows-latest-3.8
           path: /tmp/w38
       - uses: actions/download-artifact@v4
         with:
-          name: windows-latest-3.11
-          path: /tmp/w311
+          name: windows-latest-3.12.0
+          path: /tmp/w312
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/u38/nat.dep /tmp/u39/nat.dep /tmp/u310/nat.dep /tmp/u311/nat.dep /tmp/m38/nat.dep /tmp/m311/nat.dep /tmp/w38/nat.dep /tmp/w311/nat.dep || true
+          sort -f -u /tmp/u38/nat.dep /tmp/u39/nat.dep /tmp/u310/nat.dep /tmp/u311/nat.dep /tmp/u312/nat.dep /tmp/m38/nat.dep /tmp/m312/nat.dep /tmp/w38/nat.dep /tmp/w312/nat.dep || true
         shell: bash
       - name: Coverage combine
         run: coverage3 combine /tmp/u38/nat.dat

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,3 @@
 numpy>=1.20.0
 ipython<8.13;python_version<'3.9'
-scipy<1.11
+scipy<1.11; python_version<'3.12'

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,2 @@
 numpy>=1.20.0
 ipython<8.13;python_version<'3.9'
-scipy<1.11; python_version<'3.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
+target-version = ['py38', 'py39', 'py310', 'py311']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312']

--- a/releasenotes/notes/py_3_12_support-ff91e3a300421b3d.yaml
+++ b/releasenotes/notes/py_3_12_support-ff91e3a300421b3d.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added support for using Qiskit Nature with Python 3.12.

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering",
     ],
     keywords="qiskit sdk quantum nature chemistry physics",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.3.0
-envlist = py38, py39, py310, py311, lint
+envlist = py38, py39, py310, py311, py312, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

See #1327 I will not mark this to close that since this still CI needs to use 3.12.0 specifically as the breaking change to testtools, referred there has not yet been addressed. So rather than have it close it and then open another specifically around juct using 3.12 when we are able, I just put a task list in there so this does one of the entries. The other will need a release of testtools first.

I marked this stable backport in order to facilitate a release that supports 3.12. 

### Details and comments

If/when merged will require branch rules updating.
