### PR TITLE
Fix the broken copyright

### DIFF
--- a/qiskit_nature/second_q/operators/__init__.py
+++ b/qiskit_nature/second_q/operators/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2022, 2023.
+# (C) Copyright IBM 2022, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/operators/test_majorana_op.py
+++ b/test/second_q/operators/test_majorana_op.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023.
+# (C) Copyright IBM 2023, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Merging #1270 led to failing CI due to wrong copyright years.
This happened because the files in the PR were last changed in 2023 until the merge commit touched them in 2024.
This has already happened in the past when PR reviews carried across the year change but is such a rare occurrence that the pipeline was not enabled to catch this.

### Details and comments


