### PR TITLE
Fix for mypy errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,9 +151,9 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.8, 3.9, '3.10', 3.11, 3.12]
         include:
-          - os: macos-latest
+          - os: macos-12
             python-version: 3.8
-          - os: macos-latest
+          - os: macos-12
             python-version: 3.12
           - os: windows-latest
             python-version: 3.8
@@ -171,7 +171,7 @@ jobs:
             requirements-dev.txt
       - name: Create conda environment
         run: |
-          if [ "${{ matrix.os }}" == "macos-latest" ]; then
+          if [ "${{ matrix.os }}" == "macos-12" ]; then
             sudo chown -R $USER: "$CONDA"
           fi
           source "$CONDA/etc/profile.d/conda.sh"
@@ -383,11 +383,11 @@ jobs:
           path: /tmp/u312
       - uses: actions/download-artifact@v4
         with:
-          name: macos-latest-3.8
+          name: macos-12-3.8
           path: /tmp/m38
       - uses: actions/download-artifact@v4
         with:
-          name: macos-latest-3.12
+          name: macos-12-3.12
           path: /tmp/m312
       - uses: actions/download-artifact@v4
         with:

--- a/qiskit_nature/second_q/operators/bosonic_op.py
+++ b/qiskit_nature/second_q/operators/bosonic_op.py
@@ -195,8 +195,6 @@ class BosonicOp(SparseLabelOp):
         return self.__class__(data, copy=False, num_modes=num_so)
 
     def _validate_keys(self, keys: Collection[str]) -> None:
-        super()._validate_keys(keys)
-
         num_so = self.num_modes
 
         max_index = -1

--- a/qiskit_nature/second_q/operators/fermionic_op.py
+++ b/qiskit_nature/second_q/operators/fermionic_op.py
@@ -196,8 +196,6 @@ class FermionicOp(SparseLabelOp):
         return self.__class__(data, copy=False, num_spin_orbitals=num_so)
 
     def _validate_keys(self, keys: Collection[str]) -> None:
-        super()._validate_keys(keys)
-
         num_so = self.num_spin_orbitals
 
         max_index = -1

--- a/qiskit_nature/second_q/operators/majorana_op.py
+++ b/qiskit_nature/second_q/operators/majorana_op.py
@@ -250,8 +250,6 @@ class MajoranaOp(SparseLabelOp):
         return self.__class__(data, copy=False, num_modes=num_modes)
 
     def _validate_keys(self, keys: Collection[str]) -> None:
-        super()._validate_keys(keys)
-
         num_modes = self.num_modes
 
         max_index = -1

--- a/qiskit_nature/second_q/operators/spin_op.py
+++ b/qiskit_nature/second_q/operators/spin_op.py
@@ -254,8 +254,6 @@ class SpinOp(SparseLabelOp):
         return self.__class__(data, copy=False, num_spins=num_s)
 
     def _validate_keys(self, keys: Collection[str]) -> None:
-        super()._validate_keys(keys)
-
         num_s = self.num_spins
 
         max_index = -1

--- a/qiskit_nature/second_q/operators/vibrational_op.py
+++ b/qiskit_nature/second_q/operators/vibrational_op.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2024.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -249,7 +249,6 @@ class VibrationalOp(SparseLabelOp):
         return self.__class__(data, copy=False, num_modals=num_modals)
 
     def _validate_keys(self, keys: Collection[str]) -> None:
-        super()._validate_keys(keys)
         num_modals = self._num_modals if self._num_modals is not None else []
 
         for key in keys:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

CI has been failing in nightlies with mypy for  couple of weeks (since the new mypy release)

```
qiskit_nature/second_q/operators/vibrational_op.py: note: In member "_validate_keys" of class "VibrationalOp":
Error: qiskit_nature/second_q/operators/vibrational_op.py:252: error: Call to abstract method "_validate_keys" of "SparseLabelOp" with trivial body via super() is unsafe  [safe-super]
qiskit_nature/second_q/operators/spin_op.py: note: In member "_validate_keys" of class "SpinOp":
Error: qiskit_nature/second_q/operators/spin_op.py:257: error: Call to abstract method "_validate_keys" of "SparseLabelOp" with trivial body via super() is unsafe  [safe-super]
qiskit_nature/second_q/operators/fermionic_op.py: note: In member "_validate_keys" of class "FermionicOp":
Error: qiskit_nature/second_q/operators/fermionic_op.py:199: error: Call to abstract method "_validate_keys" of "SparseLabelOp" with trivial body via super() is unsafe  [safe-super]
qiskit_nature/second_q/operators/bosonic_op.py: note: In member "_validate_keys" of class "BosonicOp":
Error: qiskit_nature/second_q/operators/bosonic_op.py:198: error: Call to abstract method "_validate_keys" of "SparseLabelOp" with trivial body via super() is unsafe  [safe-super]
qiskit_nature/second_q/operators/majorana_op.py: note: In member "_validate_keys" of class "MajoranaOp":
Error: qiskit_nature/second_q/operators/majorana_op.py:253: error: Call to abstract method "_validate_keys" of "SparseLabelOp" with trivial body via super() is unsafe  [safe-super]
Found 5 errors in 5 files (checked 324 source files)
make: *** [Makefile:48: mypy] Error 1
Error: Process completed with exit code 2.
```

`_validate_keys()` in the parent SparseLabelOp is defined as an abstract method! I removed these calls to super from the above


### Details and comments

Stable branch would have the same issue but I did not label this for backporting as it includes a file (the majorana op) that is only present on main.
