### PR TITLE
Replace np.alltrue() with np.all()

### DIFF
--- a/test/second_q/mappers/test_bksf_mapper.py
+++ b/test/second_q/mappers/test_bksf_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2023.
+# (C) Copyright IBM 2021, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/second_q/mappers/test_bksf_mapper.py
+++ b/test/second_q/mappers/test_bksf_mapper.py
@@ -100,7 +100,7 @@ class TestBravyiKitaevSuperFastMapper(QiskitNatureTestCase):
     def test_h2(self):
         """Test H2 molecule"""
         with self.subTest("Excitation edges 1"):
-            assert np.alltrue(
+            assert np.all(
                 _bksf_edge_list_fermionic_op(
                     FermionicOp({"+_0 -_1 +_2 -_3": 1}, num_spin_orbitals=4),
                     4,
@@ -109,7 +109,7 @@ class TestBravyiKitaevSuperFastMapper(QiskitNatureTestCase):
             )
 
         with self.subTest("Excitation edges 2"):
-            assert np.alltrue(
+            assert np.all(
                 _bksf_edge_list_fermionic_op(
                     FermionicOp({"+_0 -_1 -_2 +_3": 1}, num_spin_orbitals=4),
                     4,


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`numpy.alltrue()` was deprecated in NumPy 1.25.0 and removed in NumPy 2.0. Because of this, `test_h2` fails on recent versions of NumPy.

This PR simply replaces `np.alltrue()` with `np.all()` as recommended by the [NumPy 2.0 migration guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#main-namespace). Test will continue to work on older versions of NumPy.

### Details and comments

Fixes: https://github.com/qiskit-community/qiskit-nature/issues/1370


