### PR TITLE
Remove `psutil` and `typing_extensions` from `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@ qiskit>=0.44
 qiskit-algorithms>=0.2.1
 scipy>=1.4
 numpy>=1.17
-psutil>=5
 setuptools>=40.1.0
-typing_extensions
 h5py
 rustworkx>=0.12


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Both `psutil` and `typing_extensions` are not used at all in this package.

### Details and comments

Similar cleaning to https://github.com/qiskit-community/qiskit-finance/pull/346 and https://github.com/qiskit-community/qiskit-machine-learning/pull/894

