### PR TITLE
Fixed PSI4 CI errors for Ubuntu (Python 3.9 and 3.10)

### DIFF
--- a/.github/actions/install-psi4/action.yml
+++ b/.github/actions/install-psi4/action.yml
@@ -26,9 +26,17 @@ runs:
         source "$CONDA/etc/profile.d/conda.sh"
         conda activate psi4env
         py_requires_libecpint=("3.9" "3.10")
-        if [[ "${{ inputs.os }}" == "ubuntu-latest" && " ${py_requires_libecpint[@]} " =~ "${{ inputs.python-version }}" ]]; then
-          echo "installs libecpint"
-          conda install -c conda-forge libecpint
+        if [[ "${{ inputs.os }}" == "ubuntu-latest" ]]; then
+          for py_ver in "${py_requires_libecpint[@]}"; do
+            if [[ "${{ inputs.python-version }}" == "$py_ver" ]]; then
+              echo "Installing libecpint for Python $py_ver"
+              conda install -c conda-forge libecpint
+              break
+            fi
+          done
+          echo $LD_LIBRARY_PATH
+          echo $CONDA
+          echo $CONDA_PREFIX
         fi
         echo "installs psi4 stable release"
         conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge

--- a/.github/actions/install-psi4/action.yml
+++ b/.github/actions/install-psi4/action.yml
@@ -37,6 +37,8 @@ runs:
           echo $LD_LIBRARY_PATH
           echo $CONDA
           echo $CONDA_PREFIX
+          export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
+          echo $LD_LIBRARY_PATH
         fi
         echo "installs psi4 stable release"
         conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge

--- a/.github/actions/install-psi4/action.yml
+++ b/.github/actions/install-psi4/action.yml
@@ -25,21 +25,6 @@ runs:
     - run : |
         source "$CONDA/etc/profile.d/conda.sh"
         conda activate psi4env
-        py_requires_libecpint=("3.9" "3.10")
-        if [[ "${{ inputs.os }}" == "ubuntu-latest" ]]; then
-          for py_ver in "${py_requires_libecpint[@]}"; do
-            if [[ "${{ inputs.python-version }}" == "$py_ver" ]]; then
-              echo "Installing libecpint for Python $py_ver"
-              conda install -c conda-forge libecpint
-              break
-            fi
-          done
-          echo $LD_LIBRARY_PATH
-          echo $CONDA
-          echo $CONDA_PREFIX
-          export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
-          echo $LD_LIBRARY_PATH
-        fi
         echo "installs psi4 stable release"
         conda install -y psi4 python=${{ inputs.python-version }} -c conda-forge/label/libint_dev -c conda-forge
       shell: bash


### PR DESCRIPTION
### Summary
This PR fixes the CI failures due to PSI4 on Ubuntu Latest with Python 3.9 and 3.10.
The fix consists in removing the explicit `libecpint` installation for Python 3.9 and 3.10 for Ubuntu. Such installation was introduced in #1374, but for some reason, it stopped working about two weeks ago (see https://github.com/qiskit-community/qiskit-nature/actions?page=2)