### PR TITLE
Update intersphinx mapping and other URLs pointing to IQP Classic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2021, 2024.
+# (C) Copyright IBM 2021, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,7 +191,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
+    "qiskit": ("https://quantum.cloud.ibm.com/docs/api/qiskit/", None),
     "qiskit-algorithms": ("https://qiskit-community.github.io/qiskit-algorithms/", None),
     "rustworkx": ("https://www.rustworkx.org/", None),
     "sparse": ("https://sparse.pydata.org/en/stable/", None),

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -8,7 +8,7 @@ Installation
 ============
 
 Qiskit Nature depends on Qiskit, which has its own
-`installation instructions <https://docs.quantum.ibm.com/start/install>`__ detailing the
+`installation instructions <https://quantum.cloud.ibm.com/docs/guides/install-qiskit>`__ detailing the
 installation options and its supported environments/platforms. You should refer to
 that first. Then the information here can be followed which focuses on the additional installation
 specific to Qiskit Nature.
@@ -22,7 +22,7 @@ See :ref:`optional_installs` for more information.
 
     .. tab-item:: Start locally
 
-        The simplest way to get started is to follow the installation guide for Qiskit `here <https://docs.quantum.ibm.com/start/install>`__
+        The simplest way to get started is to follow the installation guide for Qiskit `here <https://quantum.cloud.ibm.com/docs/guides/install-qiskit>`__
 
         In your virtual environment, where you installed Qiskit, install ``qiskit-nature`` as follows:
 
@@ -45,7 +45,7 @@ See :ref:`optional_installs` for more information.
 
        Since Qiskit Nature depends on Qiskit, and its latest changes may require new or changed
        features of Qiskit, you should first follow Qiskit's `"Install from source"` instructions
-       `here <https://docs.quantum.ibm.com/start/install-qiskit-source>`__
+       `here <https://quantum.cloud.ibm.com/docs/guides/install-qiskit-source>`__
 
        .. raw:: html
 

--- a/docs/migration/0.5_b_solving_problems.rst
+++ b/docs/migration/0.5_b_solving_problems.rst
@@ -10,11 +10,11 @@ problems. Nonetheless, the ``algorithms`` module and supporting modules
 did also receive significant updates. Most importantly all algorithms In
 Nature are now dependent on the new Qiskit Terra algorithms, and these
 are now based on `Qiskit
-Primitives <https://docs.quantum.ibm.com/run/primitives>`__
+Primitives <https://quantum.cloud.ibm.com/docs/guides/primitives>`__
 and were added in Qiskit Terra 0.22. It is not the intention to provide
 detailed explanations of the primitives in this migration guide. We
 suggest that you read the `corresponding
-resources <https://docs.quantum.ibm.com/api/qiskit/primitives>`__
+resources <https://quantum.cloud.ibm.com/docs/api/qiskit/primitives>`__
 of the Qiskit Terra documentation instead.
 
 Further Resources
@@ -247,7 +247,7 @@ This module was moved to
 updating your imports, you need to pay attention to the following:
 
 -  the ``QEOM`` API now also requires an `Estimator
-   primitiver <https://docs.quantum.ibm.com/api/qiskit/qiskit.primitives.BaseEstimator>`__
+   primitiver <https://quantum.cloud.ibm.com/docs/api/qiskit/qiskit.primitives.BaseEstimator>`__
    to be provided
 
 Previously

--- a/docs/tutorials/03_ground_state_solvers.ipynb
+++ b/docs/tutorials/03_ground_state_solvers.ipynb
@@ -125,7 +125,7 @@
    "source": [
     "To define the VQE solver one needs three essential elements:\n",
     "\n",
-    "1. An Estimator primitive: these were released as part of Qiskit Terra 0.22. To learn more about primitives, check out [this resource](https://docs.quantum.ibm.com/api/qiskit/primitives).\n",
+    "1. An Estimator primitive: these were released as part of Qiskit Terra 0.22. To learn more about primitives, check out [this resource](https://quantum.cloud.ibm.com/docs/api/qiskit/primitives).\n",
     "2. A variational form: here we use the Unitary Coupled Cluster (UCC) ansatz (see for instance [Physical Review A 98.2 (2018): 022322]). Since it is a chemistry standard, a factory is already available allowing a fast initialization of a VQE with UCC. The default is to use all single and double excitations. However, the excitation type (S, D, SD) as well as other parameters can be selected. We also prepend the `UCCSD` variational form with a `HartreeFock` initial state, which initializes the occupation of our qubits according to the problem which we are trying solve.\n",
     "3. An optimizer: this is the classical piece of code in charge of optimizing the parameters in our variational form. See [the corresponding documentation](https://qiskit-community.github.io/qiskit-algorithms/apidocs/qiskit_algorithms.optimizers.html) for more information.\n",
     "\n",

--- a/qiskit_nature/second_q/mappers/bosonic_linear_mapper.py
+++ b/qiskit_nature/second_q/mappers/bosonic_linear_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2024.
+# (C) Copyright IBM 2023, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/mappers/bosonic_mapper.py
+++ b/qiskit_nature/second_q/mappers/bosonic_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2024.
+# (C) Copyright IBM 2023, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/mappers/majorana_mapper.py
+++ b/qiskit_nature/second_q/mappers/majorana_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2024.
+# (C) Copyright IBM 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/mappers/mode_based_mapper.py
+++ b/qiskit_nature/second_q/mappers/mode_based_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2023, 2024.
+# (C) Copyright IBM 2023, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_nature/second_q/mappers/ternary_tree_mapper.py
+++ b/qiskit_nature/second_q/mappers/ternary_tree_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2024.
+# (C) Copyright IBM 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/releasenotes/notes/0.5/0.5-prelude-a1d20e9b76893ece.yaml
+++ b/releasenotes/notes/0.5/0.5-prelude-a1d20e9b76893ece.yaml
@@ -33,7 +33,7 @@ features:
   - |
     The ``algorithms`` module now requires the new algorithms introduced in
     Qiskit Terra 0.22 which in turn rely on the `Qiskit Primitives
-    <https://docs.quantum.ibm.com/api/qiskit/primitives>`_ themselves.
+    <https://quantum.cloud.ibm.com/docs/api/qiskit/primitives>`_ themselves.
     For more details check out the `migration guide for problem solving
     <https://qiskit-community.github.io/qiskit-nature/migration/0.5_b_solving_problems.html>`_.
   - |

--- a/test/second_q/mappers/test_ternary_tree_mapper.py
+++ b/test/second_q/mappers/test_ternary_tree_mapper.py
@@ -1,6 +1,6 @@
 # This code is part of a Qiskit project.
 #
-# (C) Copyright IBM 2024.
+# (C) Copyright IBM 2024, 2025.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory


### PR DESCRIPTION
The documentation source of truth is moving to https://quantum.cloud.ibm.com/.